### PR TITLE
Add test for stale element on android variant

### DIFF
--- a/DotNet/overrides.js
+++ b/DotNet/overrides.js
@@ -64,4 +64,5 @@ module.exports = {
 	// 'should send dom and location when check region by selector fully with custom scroll root': { skipEmit: true },
 	// 'should send dom and location when check region by selector fully with custom scroll root with vg': { skipEmit: true },
 	// 'should send dom of version 11': { skipEmit: true },
+	'should not fail if scroll root is stale on android': {skipEmit: true},
 }

--- a/coverage-tests.js
+++ b/coverage-tests.js
@@ -1398,6 +1398,10 @@ test('should set viewport size', {
 })
 
 test('should not fail if scroll root is stale', {
+  variants: {
+    '': {env: {browser: 'chrome'}},
+    'on android': {env: {browser: 'chrome', device: 'Android 8.0 Chrome Emulator'}},
+  },
   test({driver, eyes}) {
     driver.visit('https://applitools.github.io/demo/TestPages/RefreshDomPage')
     eyes.open({appName: 'Applitools Eyes SDK', viewportSize: {width: 600, height: 500}})

--- a/java/overrides.js
+++ b/java/overrides.js
@@ -71,5 +71,6 @@ module.exports = {
     'should send dom and location when check region by selector with custom scroll root with vg': {skipEmit: true},
     'should send dom and location when check region by selector fully with custom scroll root': {skipEmit: true},
     'should send dom and location when check region by selector fully with custom scroll root with vg': {skipEmit: true},
-    'should send dom of version 11': {skipEmit: true}
+    'should send dom of version 11': {skipEmit: true},
+    'should not fail if scroll root is stale on android': {skipEmit: true},
 }

--- a/python/overrides.js
+++ b/python/overrides.js
@@ -100,4 +100,5 @@ module.exports = {
     'appium iOS check window': {skip: true},							//assertion for ignored region fails
     'appium iOS check region with ignore region': {skip: true},					//assertion for ignored region fails
     'appium iOS check region': {skip: true},							//wrong  scale
+    'should not fail if scroll root is stale on android': {skipEmit: true},
 }

--- a/ruby/overrides.js
+++ b/ruby/overrides.js
@@ -165,4 +165,5 @@ module.exports = {
     // A bug in the full page algorithm to fix
     'check window fully with html scrollRootElement after scroll when fail to scroll with scroll stitching': {skip: true},
     'check window fully with html scrollRootElement after scroll when fail to scroll with css stitching': {skip: true},
+    'should not fail if scroll root is stale on android': {skipEmit: true},
 }


### PR DESCRIPTION
In JS SDK's we cache the scroll root element. So between page navigations we get a stale element reference error. In those cases we refresh the element (find it again), but there was a bug that in mobile we didn't do it, since we don't hide scrollbars there.

This should pass for non-js SDK's without any extra work - just need to verify.
I skip this by default - other SDK's need to verify and enable it.