### PR TITLE
Add test for region in frame on firefox 48

### DIFF
--- a/DotNet/overrides.js
+++ b/DotNet/overrides.js
@@ -64,4 +64,5 @@ module.exports = {
 	// 'should send dom and location when check region by selector fully with custom scroll root': { skipEmit: true },
 	// 'should send dom and location when check region by selector fully with custom scroll root with vg': { skipEmit: true },
 	// 'should send dom of version 11': { skipEmit: true },
+	'check region by selector in frame fully on firefox legacy': { skipEmit: true },
 }

--- a/coverage-tests.js
+++ b/coverage-tests.js
@@ -600,6 +600,7 @@ test('check region by selector in frame fully', {
     'with css stitching': {config: {stitchMode: 'CSS', baselineName: 'TestCheckRegionInFrame'}},
     'with scroll stitching': {config: {stitchMode: 'Scroll', baselineName: 'TestCheckRegionInFrame_Scroll'}},
     'with vg': {vg: true, config: {baselineName: 'TestCheckRegionInFrame_VG'}},
+    'on firefox legacy': {config: {baselineName: 'TestCheckRegionInFrame_Scroll'}, env: {browser: 'firefox-48', legacy: true}}
   },
   test({eyes}) {
     eyes.open({appName: 'Eyes Selenium SDK - Classic API', viewportSize})
@@ -1398,6 +1399,10 @@ test('should set viewport size', {
 })
 
 test('should not fail if scroll root is stale', {
+  variants: {
+    '': {env: {browser: 'chrome'}},
+    'on android': {env: {browser: 'chrome', device: 'Android 8.0 Chrome Emulator'}},
+  },
   test({driver, eyes}) {
     driver.visit('https://applitools.github.io/demo/TestPages/RefreshDomPage')
     eyes.open({appName: 'Applitools Eyes SDK', viewportSize: {width: 600, height: 500}})

--- a/coverage-tests.js
+++ b/coverage-tests.js
@@ -1399,10 +1399,6 @@ test('should set viewport size', {
 })
 
 test('should not fail if scroll root is stale', {
-  variants: {
-    '': {env: {browser: 'chrome'}},
-    'on android': {env: {browser: 'chrome', device: 'Android 8.0 Chrome Emulator'}},
-  },
   test({driver, eyes}) {
     driver.visit('https://applitools.github.io/demo/TestPages/RefreshDomPage')
     eyes.open({appName: 'Applitools Eyes SDK', viewportSize: {width: 600, height: 500}})

--- a/java/overrides.js
+++ b/java/overrides.js
@@ -71,5 +71,6 @@ module.exports = {
     'should send dom and location when check region by selector with custom scroll root with vg': {skipEmit: true},
     'should send dom and location when check region by selector fully with custom scroll root': {skipEmit: true},
     'should send dom and location when check region by selector fully with custom scroll root with vg': {skipEmit: true},
-    'should send dom of version 11': {skipEmit: true}
+    'should send dom of version 11': {skipEmit: true},
+    'check region by selector in frame fully on firefox legacy': { skipEmit: true },
 }

--- a/python/overrides.js
+++ b/python/overrides.js
@@ -100,4 +100,5 @@ module.exports = {
     'appium iOS check window': {skip: true},							//assertion for ignored region fails
     'appium iOS check region with ignore region': {skip: true},					//assertion for ignored region fails
     'appium iOS check region': {skip: true},							//wrong  scale
+    'check region by selector in frame fully on firefox legacy': { skipEmit: true },
 }

--- a/ruby/overrides.js
+++ b/ruby/overrides.js
@@ -165,4 +165,5 @@ module.exports = {
     // A bug in the full page algorithm to fix
     'check window fully with html scrollRootElement after scroll when fail to scroll with scroll stitching': {skip: true},
     'check window fully with html scrollRootElement after scroll when fail to scroll with css stitching': {skip: true},
+    'check region by selector in frame fully on firefox legacy': { skipEmit: true },
 }


### PR DESCRIPTION
This is a test for the image provider of old firefox versions.
The capabilities used in JS for `{ browser: 'firefox-48', legacy: true}` are:
```
  'firefox-48': {
    type: 'sauce',
    url: SAUCE_SERVER_URL,
    capabilities: {
      legacy: {
        browserName: 'firefox',
        platform: 'Windows 10',
        version: '48.0',
      },
    },
    options: {
      name: 'Firefox 48',
      ...SAUCE_CREDENTIALS,
    },
  },
```

The legacy flag means that it's a legacy protocol of sauce, so not using `sauce:options`.