### PR TITLE
Remove skip for two DotNet generic tests

### DIFF
--- a/DotNet/overrides.js
+++ b/DotNet/overrides.js
@@ -4,8 +4,6 @@ module.exports = {
 	// window
 	'check window with layout breakpoints in config': { skip: true }, // layout breakpoints are not implemented
 	'check window with layout breakpoints': { skip: true }, // layout breakpoints are not implemented
-	'check window fully on page with sticky header with css stitching': { skip: true },   //diff
-	'check window fully on page with sticky header with scroll stitching': { skip: true },   //diff
 	'check window fully with fixed scroll root element': { skip: true },   //diff
 	'check window on page with sticky header with vg': { skip: true },   //diff
 	'should set viewport size': { skip: true },   //Actual region with Width=800 Height=600 don't equal to expected region with Width = 600 Height = 600


### PR DESCRIPTION
Remove skip for DotNet generic tests 'check window fully on page with sticky header with css stitching' and 'check window fully on page with sticky header with scroll stitching'