### PR TITLE
Remove skip for 2 Ruby tests

### DIFF
--- a/ruby/overrides.js
+++ b/ruby/overrides.js
@@ -36,6 +36,7 @@ module.exports = {
     'should send dom and location when check region by selector with custom scroll root': {skipEmit: true},
     'should send dom and location when check region by selector with custom scroll root with vg': {skipEmit: true},
     'should send dom and location when check region by selector fully with custom scroll root': {skipEmit: true},
+	'should send dom and location when check region by selector fully with custom scroll root with vg': {skipEmit: true},
     // Missing (Or I could find a scroll root option)
     'check region by selector in overflowed frame fully with css stitching': {skipEmit: true},
     'check region by selector in overflowed frame fully with scroll stitching': {skipEmit: true},
@@ -82,7 +83,7 @@ module.exports = {
     'check region by coordinates in frame with css stitching': {skip: true},
     'check region by selector after manual scroll with css stitching': {skip: true},
     'check region by selector in overflowed frame after manual scroll with css stitching': {skip: true},
-    'check region by selector after manual scroll with scroll stitching': {skip: true},
+    'check region by selector after manual scroll with scroll stitching': {config: {branchName: 'current_ruby'}}, // diffs if compare to common baseline
     'check region by selector fully on page with sticky header with css stitching': {skip: true},
     'check region by selector fully on page with sticky header with scroll stitching': {skip: true},
     'check region by selector in frame multiple times with scroll stitching': {skip: true},
@@ -104,7 +105,7 @@ module.exports = {
     'check fixed region by selector fully with css stitching': {skip: true},
     'check fixed region by selector with css stitching': {skip: true},
     'check frame fully with vg': {skip: true},
-    'check frame fully with css stitching': {skip: true},
+    'check frame fully with css stitching': {config: {branchName: 'current_ruby'}}, // diffs if compare to common baseline
     'check frame after manual switch to frame with scroll stitching classic': {skip: true},
     'should send floating region by coordinates in frame with css stitching': {skip: true},
     'should send floating region by coordinates in frame with vg': {skip: true},
@@ -163,8 +164,8 @@ module.exports = {
     'should not check if disabled': {skip: true},
 
     // A bug in the full page algorithm to fix
-    'check window fully with html scrollRootElement after scroll when fail to scroll with scroll stitching': {skip: true},
-    'check window fully with html scrollRootElement after scroll when fail to scroll with css stitching': {skip: true},
+    'check window fully with html scrollRootElement after scroll when fail to scroll with scroll stitching': {skipEmit: true},
+    'check window fully with html scrollRootElement after scroll when fail to scroll with css stitching': {skipEmit: true},
     'should not fail if scroll root is stale on android': {skipEmit: true},
     'check region by selector in frame fully on firefox legacy': { skipEmit: true },
     'should send custom batch properties': {skipEmit: true},

--- a/ruby/overrides.js
+++ b/ruby/overrides.js
@@ -36,7 +36,6 @@ module.exports = {
     'should send dom and location when check region by selector with custom scroll root': {skipEmit: true},
     'should send dom and location when check region by selector with custom scroll root with vg': {skipEmit: true},
     'should send dom and location when check region by selector fully with custom scroll root': {skipEmit: true},
-	'should send dom and location when check region by selector fully with custom scroll root with vg': {skipEmit: true},
     // Missing (Or I could find a scroll root option)
     'check region by selector in overflowed frame fully with css stitching': {skipEmit: true},
     'check region by selector in overflowed frame fully with scroll stitching': {skipEmit: true},
@@ -164,8 +163,8 @@ module.exports = {
     'should not check if disabled': {skip: true},
 
     // A bug in the full page algorithm to fix
-    'check window fully with html scrollRootElement after scroll when fail to scroll with scroll stitching': {skipEmit: true},
-    'check window fully with html scrollRootElement after scroll when fail to scroll with css stitching': {skipEmit: true},
+    'check window fully with html scrollRootElement after scroll when fail to scroll with scroll stitching': {skip: true},
+    'check window fully with html scrollRootElement after scroll when fail to scroll with css stitching': {skip: true},
     'should not fail if scroll root is stale on android': {skipEmit: true},
     'check region by selector in frame fully on firefox legacy': { skipEmit: true },
     'should send custom batch properties': {skipEmit: true},


### PR DESCRIPTION
Remove skip for Ruby tests 'check region by selector after manual scroll with scroll stitching' and 'check frame fully with css stitching'. For these tests was made new baseline branch 'current_ruby' and new baselines for the tests in it