### PR TITLE
Add test for agentRunId

### DIFF
--- a/DotNet/overrides.js
+++ b/DotNet/overrides.js
@@ -73,4 +73,7 @@ module.exports = {
     'should return aborted tests in getAllTestResults': {skipEmit: true},
     'should return aborted tests in getAllTestResults with vg': {skipEmit: true},
     'should return browserInfo in getAllTestResults': {skipEmit: true},
+
+	// TODO verify and enable
+    'should send agentRunId': {skipEmit: true},
 }

--- a/coverage-tests.js
+++ b/coverage-tests.js
@@ -2066,4 +2066,27 @@ test('should return browserInfo in getAllTestResults', {
   },
 })
 
+
+test('should send agentRunId', {
+  page: 'Default',
+  vg: true,
+  config: {
+    browsersInfo: [
+      {name: 'chrome', width: 400, height: 400},
+      {name: 'chrome', width: 500, height: 500}
+    ]
+  },
+  test({eyes, assert, helpers}) {
+    eyes.open({appName: 'Eyes Selenium SDK', viewportSize});
+    eyes.check({fully: false});
+    eyes.close(false)
+    const resultSummary = eyes.runner.getAllTestResults(false)
+    const info1 = helpers.getTestInfo(resultSummary.getAllResults()[0].testResults);
+    const info2 = helpers.getTestInfo(resultSummary.getAllResults()[1].testResults); 
+    assert.ok(info1.startInfo.agentRunId)
+    assert.equal(info1.startInfo.agentRunId, info2.startInfo.agentRunId)
+  },
+})
+
+
 // #endregion

--- a/java/overrides.js
+++ b/java/overrides.js
@@ -43,4 +43,7 @@ module.exports = {
     // RESPONSE: {"name":"EyesManager.closeManager","key":"36cd5684-44c2-4b96-a217-803d1efc7981","payload":{"result":{"results":[],"passed":0,"unresolved":0,"failed":0,"exceptions":0,"mismatches":0,"missing":0,"matches":0}}}
     'check window on mobile web android': {skip: true},
 
+    // TODO verify and enable
+    'should send agentRunId': {skipEmit: true},
+
 }

--- a/python/overrides.js
+++ b/python/overrides.js
@@ -12,4 +12,7 @@ module.exports = {
     // Failing on the universal server 1.10 and lower
     // check on new universal server version
     "check window on mobile web android": {skip: true},
+
+    // TODO verify and enable
+    'should send agentRunId': {skipEmit: true},
 }


### PR DESCRIPTION
This should be merged only once it is supported in eyes.applitools.com
I'm not sure non-JS emitters will support the getter methods on the TestResultSummary and TestResultContainer though.