### PR TITLE
Remove skip for 2 dotnet generic tests - use special branches

### DIFF
--- a/DotNet/overrides.js
+++ b/DotNet/overrides.js
@@ -4,7 +4,7 @@ module.exports = {
 	// window
 	//'check window with layout breakpoints in config': { skip: true }, // layout breakpoints are not implemented
 	//'check window with layout breakpoints': { skip: true }, // layout breakpoints are not implemented
-	'check window fully with fixed scroll root element': { skip: true },   //diff
+	'check window fully with fixed scroll root element': { config: {branchName: 'current1'}  },   //diffs if compare to common baseline
 	'check window on page with sticky header with vg': { skip: true },   //diff
 	'should set viewport size': { skip: true },   //Actual region with Width=800 Height=600 don't equal to expected region with Width = 600 Height = 600
 	'should set viewport size on edge legacy': { skip: true },   //Actual region with Width=1024 Height=695 don't equal to expected region with Width = 600 Height = 600
@@ -24,7 +24,7 @@ module.exports = {
 	'should send ignore regions by selector with scroll stitching': { skip: true },   //actual Region region (10, 286) 285x165 not found in expected regions list.   It's other regions in original specific test TestCheckFullWindowWithMultipleIgnoreRegionsBySelector_Fluent for CSS and Scroll
 	//'check region in frame hidden under top bar fully with css stitching': {skip: true}, // Bad test
 	//frame
-	'check frame fully with css stitching': { config: {branchName: 'current_ruby'} },   //diff
+	'check frame fully with css stitching': { config: {branchName: 'current_ruby'} },   //diffs if compare to common baseline
 	'check frame fully with vg': { skip: true },   //diff
 	'check region by selector in overflowed frame fully with css stitching': { skip: true },   //diff
 	'check region by selector in overflowed frame fully with scroll stitching': { skip: true },   //diff

--- a/DotNet/overrides.js
+++ b/DotNet/overrides.js
@@ -22,7 +22,7 @@ module.exports = {
 	'should send accessibility regions by selector with scroll stitching': { skip: true },   //actual region AccessibilityRegionByRectangle (10, 286) 285x165 - LargeText not found in expected regions list. - It's other regions in original specific test TestAccessibilityRegions for CSS and Scroll
 	'should send ignore regions by selector with css stitching': { skip: true },   //actual Region region (10, 286) 285x165 not found in expected regions list.   It's other regions in original specific test TestCheckFullWindowWithMultipleIgnoreRegionsBySelector_Fluent for CSS and Scroll
 	'should send ignore regions by selector with scroll stitching': { skip: true },   //actual Region region (10, 286) 285x165 not found in expected regions list.   It's other regions in original specific test TestCheckFullWindowWithMultipleIgnoreRegionsBySelector_Fluent for CSS and Scroll
-	//'check region in frame hidden under top bar fully with css stitching': {skip: true}, // Bad test
+	'check region in frame hidden under top bar fully with css stitching': {skip: true}, // Bad test
 	//frame
 	'check frame fully with css stitching': { config: {branchName: 'current_ruby'} },   //diffs if compare to common baseline
 	'check frame fully with vg': { skip: true },   //diff

--- a/DotNet/overrides.js
+++ b/DotNet/overrides.js
@@ -1,44 +1,7 @@
 module.exports = {
-	// api
-	'should throw if no checkpoints before close' : { skip: true }, // where did this requirement come from?
-	// window
-	//'check window with layout breakpoints in config': { skip: true }, // layout breakpoints are not implemented
-	//'check window with layout breakpoints': { skip: true }, // layout breakpoints are not implemented
-	'check window fully with fixed scroll root element': { skip: true },   //diff
-	'check window on page with sticky header with vg': { skip: true },   //diff
-	'should set viewport size': { skip: true },   //Actual region with Width=800 Height=600 don't equal to expected region with Width = 600 Height = 600
-	'should set viewport size on edge legacy': { skip: true },   //Actual region with Width=1024 Height=695 don't equal to expected region with Width = 600 Height = 600
-	'should return actual viewport size': { skip: true },   //Chrome failed to start: exited abnormally
-	//region
-	'check regions by coordinates in frame with css stitching': { skip: true }, //Unable to locate element: {"method":"css selector","selector":"#modal2"}
-	'check regions by coordinates in frame with scroll stitching': { skip: true }, //Unable to locate element: {"method":"css selector","selector":"#modal2"}
-	'check regions by coordinates in overflowed frame with css stitching': { skip: true }, //Unable to locate element: {"method":"css selector","selector":"#modal3"}
-	'check regions by coordinates in overflowed frame with scroll stitching': { skip: true }, //Unable to locate element: {"method":"css selector","selector":"#modal3"}
-	'should find regions by visual locator': { skip: true }, //VisualLocators are not implemented in DotNet SDK
-	'should find regions by visual locator with vg': { skip: true }, //VisualLocators are not implemented in DotNet SDK
-	'check window after manual scroll with vg': { skip: true },   //diff
-	'check window after manual scroll on safari 12': { skip: true },   //diff
-	'should send accessibility regions by selector with css stitching': { skip: true },   //actual region AccessibilityRegionByRectangle (10, 286) 285x165 - LargeText not found in expected regions list. - It's other regions in original specific test TestAccessibilityRegions for CSS and Scroll
-	'should send accessibility regions by selector with scroll stitching': { skip: true },   //actual region AccessibilityRegionByRectangle (10, 286) 285x165 - LargeText not found in expected regions list. - It's other regions in original specific test TestAccessibilityRegions for CSS and Scroll
-	'should send ignore regions by selector with css stitching': { skip: true },   //actual Region region (10, 286) 285x165 not found in expected regions list.   It's other regions in original specific test TestCheckFullWindowWithMultipleIgnoreRegionsBySelector_Fluent for CSS and Scroll
-	'should send ignore regions by selector with scroll stitching': { skip: true },   //actual Region region (10, 286) 285x165 not found in expected regions list.   It's other regions in original specific test TestCheckFullWindowWithMultipleIgnoreRegionsBySelector_Fluent for CSS and Scroll
-	'check region in frame hidden under top bar fully with css stitching': {skip: true}, // Bad test
 	//frame
-	'check frame fully with css stitching': { skip: true },   //diff
-	'check frame fully with vg': { skip: true },   //diff
-	'check region by selector in overflowed frame fully with css stitching': { skip: true },   //diff
-	'check region by selector in overflowed frame fully with scroll stitching': { skip: true },   //diff
-	//unknown issue
-	'check window after manual scroll on safari 11': { skip: true },   //NoSuchWindowException : A request to use a window could not be satisfied because the window could not be found
 	'should extract text from regions': { skipEmit: true },   //test not implemented yet. It exists for JS only now
 	'should extract text regions from image': {skipEmit: true},   // Not implemented yet
-	// can be quick fixed
-	'check region by native selector': { skip: true }, //To fit in existing baseline for C# should have test name "Appium_Android_CheckRegion"
-	'check frame in frame fully with vg': { skip: true },  //baseline NEW. Need compare with JS tests, maybe add baseline.
-	// check many
-	'acme login with css stitching': { skip: true }, // original test tested fluent API's check many. This test doesn't.
-	'acme login with scroll stitching': { skip: true }, // original test tested fluent API's check many. This test doesn't.
-	'acme login with vg': { skip: true }, // original test tested fluent API's check many. This test doesn't.
 	// location
 	// 'should send dom and location when check window': { skipEmit: true },
 	'should send dom and location when check window with vg': { skipEmit: true },

--- a/DotNet/overrides.js
+++ b/DotNet/overrides.js
@@ -35,8 +35,6 @@ module.exports = {
 	// can be quick fixed
 	'check region by native selector': { skip: true }, //To fit in existing baseline for C# should have test name "Appium_Android_CheckRegion"
 	'check frame in frame fully with vg': { skip: true },  //baseline NEW. Need compare with JS tests, maybe add baseline.
-	// check many
-	'acme login with css stitching': { skip: true }, // original test tested fluent API's check many. This test doesn't.
 	// location
 	// 'should send dom and location when check window': { skipEmit: true },
 	'should send dom and location when check window with vg': { skipEmit: true },

--- a/DotNet/overrides.js
+++ b/DotNet/overrides.js
@@ -1,7 +1,42 @@
 module.exports = {
+	// api
+	'should throw if no checkpoints before close' : { skip: true }, // where did this requirement come from?
+	// window
+	//'check window with layout breakpoints in config': { skip: true }, // layout breakpoints are not implemented
+	//'check window with layout breakpoints': { skip: true }, // layout breakpoints are not implemented
+	'check window fully with fixed scroll root element': { skip: true },   //diff
+	'check window on page with sticky header with vg': { skip: true },   //diff
+	'should set viewport size': { skip: true },   //Actual region with Width=800 Height=600 don't equal to expected region with Width = 600 Height = 600
+	'should set viewport size on edge legacy': { skip: true },   //Actual region with Width=1024 Height=695 don't equal to expected region with Width = 600 Height = 600
+	'should return actual viewport size': { skip: true },   //Chrome failed to start: exited abnormally
+	//region
+	'check regions by coordinates in frame with css stitching': { skip: true }, //Unable to locate element: {"method":"css selector","selector":"#modal2"}
+	'check regions by coordinates in frame with scroll stitching': { skip: true }, //Unable to locate element: {"method":"css selector","selector":"#modal2"}
+	'check regions by coordinates in overflowed frame with css stitching': { skip: true }, //Unable to locate element: {"method":"css selector","selector":"#modal3"}
+	'check regions by coordinates in overflowed frame with scroll stitching': { skip: true }, //Unable to locate element: {"method":"css selector","selector":"#modal3"}
+	'should find regions by visual locator': { skip: true }, //VisualLocators are not implemented in DotNet SDK
+	'should find regions by visual locator with vg': { skip: true }, //VisualLocators are not implemented in DotNet SDK
+	'check window after manual scroll with vg': { skip: true },   //diff
+	'check window after manual scroll on safari 12': { skip: true },   //diff
+	'should send accessibility regions by selector with css stitching': { skip: true },   //actual region AccessibilityRegionByRectangle (10, 286) 285x165 - LargeText not found in expected regions list. - It's other regions in original specific test TestAccessibilityRegions for CSS and Scroll
+	'should send accessibility regions by selector with scroll stitching': { skip: true },   //actual region AccessibilityRegionByRectangle (10, 286) 285x165 - LargeText not found in expected regions list. - It's other regions in original specific test TestAccessibilityRegions for CSS and Scroll
+	'should send ignore regions by selector with css stitching': { skip: true },   //actual Region region (10, 286) 285x165 not found in expected regions list.   It's other regions in original specific test TestCheckFullWindowWithMultipleIgnoreRegionsBySelector_Fluent for CSS and Scroll
+	'should send ignore regions by selector with scroll stitching': { skip: true },   //actual Region region (10, 286) 285x165 not found in expected regions list.   It's other regions in original specific test TestCheckFullWindowWithMultipleIgnoreRegionsBySelector_Fluent for CSS and Scroll
+	'check region in frame hidden under top bar fully with css stitching': {skip: true}, // Bad test
 	//frame
+	'check frame fully with css stitching': { skip: true },   //diff
+	'check frame fully with vg': { skip: true },   //diff
+	'check region by selector in overflowed frame fully with css stitching': { skip: true },   //diff
+	'check region by selector in overflowed frame fully with scroll stitching': { skip: true },   //diff
+	//unknown issue
+	'check window after manual scroll on safari 11': { skip: true },   //NoSuchWindowException : A request to use a window could not be satisfied because the window could not be found
 	'should extract text from regions': { skipEmit: true },   //test not implemented yet. It exists for JS only now
 	'should extract text regions from image': {skipEmit: true},   // Not implemented yet
+	// can be quick fixed
+	'check region by native selector': { skip: true }, //To fit in existing baseline for C# should have test name "Appium_Android_CheckRegion"
+	'check frame in frame fully with vg': { skip: true },  //baseline NEW. Need compare with JS tests, maybe add baseline.
+	// check many
+	'acme login with css stitching': { skip: true }, // original test tested fluent API's check many. This test doesn't.
 	// location
 	// 'should send dom and location when check window': { skipEmit: true },
 	'should send dom and location when check window with vg': { skipEmit: true },

--- a/DotNet/overrides.js
+++ b/DotNet/overrides.js
@@ -4,37 +4,19 @@ module.exports = {
 	// window
 	//'check window with layout breakpoints in config': { skip: true }, // layout breakpoints are not implemented
 	//'check window with layout breakpoints': { skip: true }, // layout breakpoints are not implemented
-	'check window fully with fixed scroll root element': { skip: true },   //diff
-	'check window on page with sticky header with vg': { skip: true },   //diff
-	'should set viewport size': { skip: true },   //Actual region with Width=800 Height=600 don't equal to expected region with Width = 600 Height = 600
-	'should set viewport size on edge legacy': { skip: true },   //Actual region with Width=1024 Height=695 don't equal to expected region with Width = 600 Height = 600
-	'should return actual viewport size': { skip: true },   //Chrome failed to start: exited abnormally
 	//region
-	'check regions by coordinates in frame with css stitching': { skip: true }, //Unable to locate element: {"method":"css selector","selector":"#modal2"}
-	'check regions by coordinates in frame with scroll stitching': { skip: true }, //Unable to locate element: {"method":"css selector","selector":"#modal2"}
-	'check regions by coordinates in overflowed frame with css stitching': { skip: true }, //Unable to locate element: {"method":"css selector","selector":"#modal3"}
-	'check regions by coordinates in overflowed frame with scroll stitching': { skip: true }, //Unable to locate element: {"method":"css selector","selector":"#modal3"}
 	'should find regions by visual locator': { skip: true }, //VisualLocators are not implemented in DotNet SDK
 	'should find regions by visual locator with vg': { skip: true }, //VisualLocators are not implemented in DotNet SDK
-	'check window after manual scroll with vg': { skip: true },   //diff
-	'check window after manual scroll on safari 12': { skip: true },   //diff
-	'should send accessibility regions by selector with css stitching': { skip: true },   //actual region AccessibilityRegionByRectangle (10, 286) 285x165 - LargeText not found in expected regions list. - It's other regions in original specific test TestAccessibilityRegions for CSS and Scroll
-	'should send accessibility regions by selector with scroll stitching': { skip: true },   //actual region AccessibilityRegionByRectangle (10, 286) 285x165 - LargeText not found in expected regions list. - It's other regions in original specific test TestAccessibilityRegions for CSS and Scroll
-	'should send ignore regions by selector with css stitching': { skip: true },   //actual Region region (10, 286) 285x165 not found in expected regions list.   It's other regions in original specific test TestCheckFullWindowWithMultipleIgnoreRegionsBySelector_Fluent for CSS and Scroll
-	'should send ignore regions by selector with scroll stitching': { skip: true },   //actual Region region (10, 286) 285x165 not found in expected regions list.   It's other regions in original specific test TestCheckFullWindowWithMultipleIgnoreRegionsBySelector_Fluent for CSS and Scroll
-	'check region in frame hidden under top bar fully with css stitching': {skip: true}, // Bad test
 	//frame
-	'check frame fully with css stitching': { skip: true },   //diff
-	'check frame fully with vg': { skip: true },   //diff
-	'check region by selector in overflowed frame fully with css stitching': { skip: true },   //diff
-	'check region by selector in overflowed frame fully with scroll stitching': { skip: true },   //diff
 	//unknown issue
-	'check window after manual scroll on safari 11': { skip: true },   //NoSuchWindowException : A request to use a window could not be satisfied because the window could not be found
 	'should extract text from regions': { skipEmit: true },   //test not implemented yet. It exists for JS only now
 	'should extract text regions from image': {skipEmit: true},   // Not implemented yet
 	// can be quick fixed
 	'check region by native selector': { skip: true }, //To fit in existing baseline for C# should have test name "Appium_Android_CheckRegion"
-	'check frame in frame fully with vg': { skip: true },  //baseline NEW. Need compare with JS tests, maybe add baseline.
+	// check many
+	'acme login with css stitching': { skip: true }, // original test tested fluent API's check many. This test doesn't.
+	'acme login with scroll stitching': { skip: true }, // original test tested fluent API's check many. This test doesn't.
+	'acme login with vg': { skip: true }, // original test tested fluent API's check many. This test doesn't.
 	// location
 	// 'should send dom and location when check window': { skipEmit: true },
 	'should send dom and location when check window with vg': { skipEmit: true },

--- a/DotNet/overrides.js
+++ b/DotNet/overrides.js
@@ -4,15 +4,37 @@ module.exports = {
 	// window
 	//'check window with layout breakpoints in config': { skip: true }, // layout breakpoints are not implemented
 	//'check window with layout breakpoints': { skip: true }, // layout breakpoints are not implemented
+	'check window fully with fixed scroll root element': { skip: true },   //diff
+	'check window on page with sticky header with vg': { skip: true },   //diff
+	'should set viewport size': { skip: true },   //Actual region with Width=800 Height=600 don't equal to expected region with Width = 600 Height = 600
+	'should set viewport size on edge legacy': { skip: true },   //Actual region with Width=1024 Height=695 don't equal to expected region with Width = 600 Height = 600
+	'should return actual viewport size': { skip: true },   //Chrome failed to start: exited abnormally
 	//region
+	'check regions by coordinates in frame with css stitching': { skip: true }, //Unable to locate element: {"method":"css selector","selector":"#modal2"}
+	'check regions by coordinates in frame with scroll stitching': { skip: true }, //Unable to locate element: {"method":"css selector","selector":"#modal2"}
+	'check regions by coordinates in overflowed frame with css stitching': { skip: true }, //Unable to locate element: {"method":"css selector","selector":"#modal3"}
+	'check regions by coordinates in overflowed frame with scroll stitching': { skip: true }, //Unable to locate element: {"method":"css selector","selector":"#modal3"}
 	'should find regions by visual locator': { skip: true }, //VisualLocators are not implemented in DotNet SDK
 	'should find regions by visual locator with vg': { skip: true }, //VisualLocators are not implemented in DotNet SDK
+	'check window after manual scroll with vg': { skip: true },   //diff
+	'check window after manual scroll on safari 12': { skip: true },   //diff
+	'should send accessibility regions by selector with css stitching': { skip: true },   //actual region AccessibilityRegionByRectangle (10, 286) 285x165 - LargeText not found in expected regions list. - It's other regions in original specific test TestAccessibilityRegions for CSS and Scroll
+	'should send accessibility regions by selector with scroll stitching': { skip: true },   //actual region AccessibilityRegionByRectangle (10, 286) 285x165 - LargeText not found in expected regions list. - It's other regions in original specific test TestAccessibilityRegions for CSS and Scroll
+	'should send ignore regions by selector with css stitching': { skip: true },   //actual Region region (10, 286) 285x165 not found in expected regions list.   It's other regions in original specific test TestCheckFullWindowWithMultipleIgnoreRegionsBySelector_Fluent for CSS and Scroll
+	'should send ignore regions by selector with scroll stitching': { skip: true },   //actual Region region (10, 286) 285x165 not found in expected regions list.   It's other regions in original specific test TestCheckFullWindowWithMultipleIgnoreRegionsBySelector_Fluent for CSS and Scroll
+	//'check region in frame hidden under top bar fully with css stitching': {skip: true}, // Bad test
 	//frame
+	'check frame fully with css stitching': { config: {branchName: 'current_ruby'} },   //diff
+	'check frame fully with vg': { skip: true },   //diff
+	'check region by selector in overflowed frame fully with css stitching': { skip: true },   //diff
+	'check region by selector in overflowed frame fully with scroll stitching': { skip: true },   //diff
 	//unknown issue
+	'check window after manual scroll on safari 11': { skip: true },   //NoSuchWindowException : A request to use a window could not be satisfied because the window could not be found
 	'should extract text from regions': { skipEmit: true },   //test not implemented yet. It exists for JS only now
 	'should extract text regions from image': {skipEmit: true},   // Not implemented yet
 	// can be quick fixed
 	'check region by native selector': { skip: true }, //To fit in existing baseline for C# should have test name "Appium_Android_CheckRegion"
+	'check frame in frame fully with vg': { skip: true },  //baseline NEW. Need compare with JS tests, maybe add baseline.
 	// check many
 	'acme login with css stitching': { skip: true }, // original test tested fluent API's check many. This test doesn't.
 	'acme login with scroll stitching': { skip: true }, // original test tested fluent API's check many. This test doesn't.


### PR DESCRIPTION
Remove skip for 'check window fully with fixed scroll root element' and 'check frame fully with css stitching' dotnet generic tests - use special branches for baselines.
Successful run - https://travis-ci.com/github/applitools/Eyes.Sdk.DotNet/builds/223095629