### PR TITLE
Remove skip for DotNet test

### DIFF
--- a/DotNet/overrides.js
+++ b/DotNet/overrides.js
@@ -22,7 +22,6 @@ module.exports = {
 	'should send accessibility regions by selector with scroll stitching': { skip: true },   //actual region AccessibilityRegionByRectangle (10, 286) 285x165 - LargeText not found in expected regions list. - It's other regions in original specific test TestAccessibilityRegions for CSS and Scroll
 	'should send ignore regions by selector with css stitching': { skip: true },   //actual Region region (10, 286) 285x165 not found in expected regions list.   It's other regions in original specific test TestCheckFullWindowWithMultipleIgnoreRegionsBySelector_Fluent for CSS and Scroll
 	'should send ignore regions by selector with scroll stitching': { skip: true },   //actual Region region (10, 286) 285x165 not found in expected regions list.   It's other regions in original specific test TestCheckFullWindowWithMultipleIgnoreRegionsBySelector_Fluent for CSS and Scroll
-	'check region in frame hidden under top bar fully with css stitching': {skip: true}, // Bad test
 	//frame
 	'check frame fully with css stitching': { config: {branchName: 'current_ruby'} },   //diffs if compare to common baseline
 	'check frame fully with vg': { skip: true },   //diff


### PR DESCRIPTION
Remove skip for DotNet 'check region in frame hidden under top bar fully with css stitching' test