### PR TITLE
add support of `variantId` for the fluent api

### DIFF
--- a/ruby/overrides.js
+++ b/ruby/overrides.js
@@ -169,8 +169,6 @@ module.exports = {
     'check region by selector in frame fully on firefox legacy': { skipEmit: true },
     'adopted styleSheets on chrome': {skipEmit: true},
 	'adopted styleSheets on firefox': {skipEmit: true},
-    'variant id': {skipEmit: true},
-	'variant id with vg': {skipEmit: true},
     // Scroll root option not implemented in the ruby SDK
     'should send dom and location when check region by selector fully with custom scroll root with vg': {skipEmit: true},
 }

--- a/ruby/overrides.js
+++ b/ruby/overrides.js
@@ -169,6 +169,7 @@ module.exports = {
     'check region by selector in frame fully on firefox legacy': { skipEmit: true },
     'adopted styleSheets on chrome': {skipEmit: true},
 	'adopted styleSheets on firefox': {skipEmit: true},
+    'variant id with vg': {skip: true},
     // Scroll root option not implemented in the ruby SDK
     'should send dom and location when check region by selector fully with custom scroll root with vg': {skipEmit: true},
 }

--- a/ruby/parser.js
+++ b/ruby/parser.js
@@ -23,6 +23,7 @@ function checkSettings(cs, driver, native) {
     if (cs.scrollRootElement ) throw new Error("Scroll root option not implemented in the ruby SDK")
     if (cs.ignoreDisplacements !== undefined) options += `.ignore_displacements(${cs.ignoreDisplacements})`
     if (cs.sendDom !== undefined) options += `.send_dom(${serialize(cs.sendDom)})`
+    if (cs.variationGroupId) options += `.variation_group_id(${serialize(cs.variationGroupId)})`
     if (cs.isFully) options += '.fully';
     if (cs.name) name = `'${cs.name}', `;
     return name + ruby + element + options


### PR DESCRIPTION
Test ex: 

```
# variant id
# Generated by Ruby template
require 'selenium_helper'

RSpec.describe 'Coverage Tests' do
  before :example do
    @driver = build_driver
    @eyes = eyes(is_visual_grid: false, is_css_stitching: false, branch_name: nil)
    eyes_config(baseline_name: 'VariantId')
  end
  after :example do
    @driver.quit
    @eyes.abort
    @runner.get_all_test_results(false)
  end
  it 'VariantId' do
    @driver.get('https://applitools.github.io/demo/TestPages/FramesTestPage/')
    @eyes.configure do |conf|
      conf.app_name = 'Applitools Eyes SDK'
      conf.test_name = 'VariantId'
      conf.viewport_size = Applitools::RectangleSize.new(700, 460)
    end
    @driver = @eyes.open(driver: @driver)
    @eyes.check(Applitools::Selenium::Target.window.variation_group_id('variant-id'))
    result = @eyes.close(false)
    info = get_test_info(result)
    expect(info['actualAppOutput'][0]['knownVariantId']).to eql('variant-id')
  end
end
```
Successful run - https://travis-ci.com/github/applitools/eyes.sdk.ruby/builds/225176000