### PR TITLE
Provide type for native selector

### DIFF
--- a/coverage-tests.js
+++ b/coverage-tests.js
@@ -537,7 +537,7 @@ test('check region by native selector', {
   config: {baselineName: 'AppiumAndroidCheckRegion'},
   test({eyes}) {
     eyes.open({appName: 'Applitools Eyes SDK'})
-    eyes.check({region: 'android.widget.Button'})
+    eyes.check({region: {type: TYPE.CLASSNAME, selector: 'android.widget.Button'}})
     eyes.close()
   },
 })


### PR DESCRIPTION
In Ruby (and maybe will be in other SDKs) element cann't be find by default selector css. If provide selector's type  the same like for test 'appium android check region' for the same element the test will work appropriate.