### PR TITLE
add assertion to `should abort if not closed`

### DIFF
--- a/coverage-tests.js
+++ b/coverage-tests.js
@@ -1486,11 +1486,12 @@ test('should abort if not closed', {
     '': {vg: false},
     'with vg': {vg: true},
   },
-  test({driver, eyes}) {
+  test({driver, eyes, assert}) {
     driver.visit('https://applitools.github.io/demo/TestPages/FramesTestPage/')
     eyes.open({appName: 'Test Abort', viewportSize: {width: 1200, height: 800}})
     eyes.check()
     eyes.abort()
+    assert.throws(() => void eyes.runner.getAllTestResults(true))
   },
 })
 


### PR DESCRIPTION
There are few difference in the abortion of the tests during several SDKs. So adding assertion will make tests to fail for some SDKs. Also aborted test have different status at different SDKs and runners.

### Dotnet
Classic runner doesn't throw an Exception
[VG aborted have a failed status](https://eyes.applitools.com/app/test-results/00000251781045479531/?accountId=xIpd7EWjhU6cjJzDGrMcUw~~)
[Classic runner aborted have an unresolved status](https://eyes.applitools.com/app/test-results/00000251781045306097/?accountId=xIpd7EWjhU6cjJzDGrMcUw~~)

### Java 
SDK classic runner doesn't adding aborted test results to the TestResultsSummary. So Classic runner doesn't throw an Exception
[VG aborted have a failed status](https://eyes.applitools.com/app/test-results/00000251781308994503/?accountId=xIpd7EWjhU6cjJzDGrMcUw~~)
[Classic runner aborted have an unresolved status](https://eyes.applitools.com/app/test-results/00000251781309027382/?accountId=xIpd7EWjhU6cjJzDGrMcUw~~)

### JS 
SDK doesn't add aborted results to the runner TestResultsSummary, so runner doesn't throw an error
[VG aborted have a failed status](https://eyes.applitools.com/app/test-results/00000251781310418326/?accountId=xIpd7EWjhU6cjJzDGrMcUw~~)
[Classic runner aborted have an unresolved status](https://eyes.applitools.com/app/test-results/00000251781310454123/?accountId=xIpd7EWjhU6cjJzDGrMcUw~~)

### Ruby 
SDK runner's method getAllTestResults returns array instead of the TestResultsSummary
Aborted tests results doesn't added to the array, so runners don't throw an error
[VG runner aborted have an unresolved status](https://eyes.applitools.com/app/test-results/00000251781309751453/?accountId=xIpd7EWjhU6cjJzDGrMcUw~~)
[Classic runner aborted have an unresolved status](https://eyes.applitools.com/app/test-results/00000251781309553401/?accountId=xIpd7EWjhU6cjJzDGrMcUw~~)

### Python 
Classic runner doesn't adding aborted test result to the TestResultsSummary. Classic runner doesn't throw an Exception. 
VG runner is stack if the `runner.getAllTestResults()` was called for the aborted test. 
[VG and Classic runner has unresolved status ](https://eyes.applitools.com/app/test-results/00000251781045392415/?accountId=xIpd7EWjhU6cjJzDGrMcUw~~)



