### PR TITLE
added waitBeforeCapture without layoutBreakpoints

### DIFF
--- a/DotNet/overrides.js
+++ b/DotNet/overrides.js
@@ -77,6 +77,9 @@ module.exports = {
   'should return browserInfo in getAllTestResults': {skipEmit: true},
   'should waitBeforeCapture in open': {skipEmit: true},
   'should waitBeforeCapture in check': {skipEmit: true},
+	'should waitBeforeCapture with breakpoints in check': {skipEmit: true},
+	'should waitBeforeCapture with breakpoints in open': {skipEmit: true},
+	'should be empty if page delayed by 1500': {skipEmit: true},
 
 	// TODO verify and enable
   'should send agentRunId': {skipEmit: true},

--- a/coverage-tests.js
+++ b/coverage-tests.js
@@ -2124,7 +2124,7 @@ test('should return browserInfo in getAllTestResults', {
   },
 })
 
-test('should waitBeforeCapture in open', {
+test('should waitBeforeCapture with breakpoints in open', {
   vg: true,
   config: {
     layoutBreakpoints: true,
@@ -2140,7 +2140,7 @@ test('should waitBeforeCapture in open', {
     eyes.close()
   },
 })
-test('should waitBeforeCapture in check', {
+test('should waitBeforeCapture with breakpoints in check', {
   vg: true,
   config: {
     browsersInfo: [
@@ -2154,6 +2154,47 @@ test('should waitBeforeCapture in check', {
       isFully: true,
       layoutBreakpoints: true,
       waitBeforeCapture: 2000,
+    })
+    eyes.close()
+  },
+})
+
+test('should waitBeforeCapture in open', {
+  vg: true,
+  config: {
+    waitBeforeCapture: 2000,
+  },
+  test({ driver, eyes }) {
+    // 'delay' (in queryString) is the time in milliseconds until image is visible in html (default is 1000)
+    driver.visit('https://applitools.github.io/demo/TestPages/waitBeforeCapture/dynamicDelay.html?delay=1000')
+    eyes.open({ appName: 'Applitools Eyes SDK', viewportSize })
+    eyes.check({ isFully: true })
+    eyes.close()
+  },
+})
+
+test('should waitBeforeCapture in check', {
+  vg: true,
+  test({ driver, eyes }) {
+    // 'delay' (in queryString) is the time in milliseconds until image is visible in html (default is 1000)
+    driver.visit('https://applitools.github.io/demo/TestPages/waitBeforeCapture/dynamicDelay.html?delay=1000')
+    eyes.open({ appName: 'Applitools Eyes SDK', viewportSize })
+    eyes.check({
+      isFully: true,
+      waitBeforeCapture: 2000,
+    })
+    eyes.close()
+  },
+})
+
+test('should be empty if page delayed by 1500', {
+  vg: true,
+  test({ driver, eyes }) {
+    // 'delay' (in queryString) is the time in milliseconds until image is visible in html (default is 1000)
+    driver.visit('https://applitools.github.io/demo/TestPages/waitBeforeCapture/dynamicDelay.html?delay=1500')
+    eyes.open({ appName: 'Applitools Eyes SDK', viewportSize })
+    eyes.check({
+      isFully: true
     })
     eyes.close()
   },

--- a/java/overrides.js
+++ b/java/overrides.js
@@ -47,6 +47,9 @@ module.exports = {
 
     'should waitBeforeCapture in open': { skipEmit: true },
     'should waitBeforeCapture in check': { skipEmit: true },
+    'should waitBeforeCapture with breakpoints in check': { skipEmit: true },
+    'should waitBeforeCapture with breakpoints in open': { skipEmit: true },
+    'should be empty if page delayed by 1500': { skipEmit: true },
       
     // TODO verify and enable
     'should send agentRunId': {skipEmit: true},

--- a/python/overrides.js
+++ b/python/overrides.js
@@ -15,6 +15,9 @@ module.exports = {
   
     'should waitBeforeCapture in open': { skipEmit: true },
     'should waitBeforeCapture in check': { skipEmit: true },
+    'should waitBeforeCapture with breakpoints in check': { skipEmit: true },
+    'should waitBeforeCapture with breakpoints in open': { skipEmit: true },
+    'should be empty if page delayed by 1500': { skipEmit: true },
 
     // TODO verify and enable
     'should send agentRunId': {skipEmit: true},

--- a/ruby/overrides.js
+++ b/ruby/overrides.js
@@ -184,4 +184,7 @@ module.exports = {
     'should return browserInfo in getAllTestResults': {skipEmit: true},
     'should waitBeforeCapture in open': { skipEmit: true },
     'should waitBeforeCapture in check': { skipEmit: true },
+    'should waitBeforeCapture with breakpoints in check': { skipEmit: true },
+    'should waitBeforeCapture with breakpoints in open': { skipEmit: true },
+    'should be empty if page delayed by 1500': { skipEmit: true },
 }


### PR DESCRIPTION
Need to approve and re-approve baselines of 5 tests:
- 'should waitBeforeCapture in open' (**existing test name** moved to new test)
- 'should waitBeforeCapture in check' (**existing test name** moved to new test)
- 'should waitBeforeCapture with breakpoints in open' (**existing test** changed test name) 
- 'should waitBeforeCapture with breakpoints in check' (**existing test** changed test name) 
- 'should be empty if page delayed by 1500' 