### PR TITLE
Test OCR regions without hints

### DIFF
--- a/DotNet/overrides.js
+++ b/DotNet/overrides.js
@@ -32,6 +32,7 @@ module.exports = {
 	'check window after manual scroll on safari 11': { skip: true },   //NoSuchWindowException : A request to use a window could not be satisfied because the window could not be found
 	'should extract text from regions': { skipEmit: true },   //test not implemented yet. It exists for JS only now
 	'should extract text regions from image': {skipEmit: true},   // Not implemented yet
+	'should extract text from regions without a hint': { skipEmit: true }, // skipping since the other OCR tests are skipped
 	// can be quick fixed
 	'check region by native selector': { skip: true }, //To fit in existing baseline for C# should have test name "Appium_Android_CheckRegion"
 	'check frame in frame fully with vg': { skip: true },  //baseline NEW. Need compare with JS tests, maybe add baseline.

--- a/coverage-tests.js
+++ b/coverage-tests.js
@@ -1533,7 +1533,6 @@ test('should extract text from regions without a hint', {
   test({driver, eyes, assert}) {
     eyes.open({appName: 'Applitools Eyes SDK', viewportSize})
     const text = eyes.extractText([
-      {target: {left: 10, top: 405, width: 210, height: 22}},
       {target: {x: 10, y: 405, width: 210, height: 22}},
       {target: {x: 10, y: 405, width: 210, height: 22}, hint: ''},
     ])

--- a/coverage-tests.js
+++ b/coverage-tests.js
@@ -1535,6 +1535,7 @@ test('should extract text from regions without a hint', {
     const text = eyes.extractText([
       {target: {left: 10, top: 405, width: 210, height: 22}},
       {target: {x: 10, y: 405, width: 210, height: 22}},
+      {target: {x: 10, y: 405, width: 210, height: 22}, hint: ''},
     ])
     eyes.close(false)
     assert.equal(text[0], 'imagination be your guide.')

--- a/coverage-tests.js
+++ b/coverage-tests.js
@@ -1527,6 +1527,21 @@ test('should extract text from regions', {
   },
 })
 
+test('should extract text from regions without a hint', {
+  page: 'OCR',
+  config: {stitchMode: 'CSS'},
+  test({driver, eyes, assert}) {
+    eyes.open({appName: 'Applitools Eyes SDK', viewportSize})
+    const text = eyes.extractText([
+      {target: {left: 10, top: 405, width: 210, height: 22}},
+      {target: {x: 10, y: 405, width: 210, height: 22}},
+    ])
+    eyes.close(false)
+    assert.equal(text[0], 'imagination be your guide.')
+    assert.equal(text[1], 'imagination be your guide.')
+  },
+})
+
 test('should extract text regions from image', {
   page: 'OCR',
   test({eyes, assert}) {

--- a/java/emitter.js
+++ b/java/emitter.js
@@ -302,7 +302,7 @@ module.exports = function (tracker, test) {
                 if (typeof (region.target) === "string") {
                     commands.push(java`By.cssSelector(${region.target}))`)
                 } else if (typeof (region.target) === "object") {
-                    commands.push(java`new Region(${region.target.left}, ${region.target.top}, ${region.target.width}, ${region.target.height}))`)
+                    commands.push(java`new Region(${region.target.left || region.target.x}, ${region.target.top || region.target.y}, ${region.target.width}, ${region.target.height}))`)
                 } else {
                     commands.push(java`${region.target})`)
                 }

--- a/python/emitter.js
+++ b/python/emitter.js
@@ -418,7 +418,7 @@ def execution_grid():
                 if (typeof (region.target) === "string") {
                     commands.push(python`[By.CSS_SELECTOR, ${region.target}])`)
                 } else if (typeof (region.target) === "object") {
-                    commands.push(python`Region(${region.target.left}, ${region.target.top}, ${region.target.width}, ${region.target.height}))`)
+                    commands.push(python`Region(${region.target.left || region.target.x}, ${region.target.top || region.target.y}, ${region.target.width}, ${region.target.height}))`)
                 } else {
                     commands.push(python`${region.target})`)
                 }

--- a/ruby/mapping/types.js
+++ b/ruby/mapping/types.js
@@ -3,7 +3,7 @@ const types = {
         constructor: (value) => `Applitools::RectangleSize.new(${value.width}, ${value.height})`
     },
     "Region": {
-        constructor: (region) => `Applitools::Region.new(${region.left}, ${region.top}, ${region.width}, ${region.height})`
+        constructor: (region) => `Applitools::Region.new(${region.left || region.x}, ${region.top || region.y}, ${region.width}, ${region.height})`
     },
     "FloatingBounds": {
         constructor: (bounds) => `Applitools::FloatingBounds.new(${bounds.maxLeftOffset}, ${bounds.maxUpOffset}, ${bounds.maxRightOffset}, ${bounds.maxDownOffset})`


### PR DESCRIPTION
Add a test for OCR regions without a hint, using both x, y and left, top.

Adds coverage for a bug found on JS core that would throw when using x, y in a region and no hint.