### PR TITLE
[WIP] Add test for UFG native

### DIFF
--- a/coverage-tests.js
+++ b/coverage-tests.js
@@ -284,6 +284,40 @@ test('check window fully on android chrome emulator', {
   },
 })
 
+test('check window UFG native', {
+  variants: {
+    'on ios': {
+      env: {
+        device: 'iPhone 12',
+        app: 'https://applitools.jfrog.io/artifactory/Examples/DuckDuckGo-instrumented.app.zip',
+        injectUFGLib: true,
+      },
+      config: {
+        browsersInfo: [
+          {iosDeviceInfo: {deviceName: 'iPhone 12', iosVersion: 'latest'}}
+        ]
+      }
+    },
+    'on android': {
+      env: {
+        device: 'Pixel 3 XL',
+        app: 'https://applitools.jfrog.io/artifactory/Examples/ufg-native-example.apk',
+      },
+      config: {
+        browsersInfo: [
+          {androidDeviceInfo: {deviceName: 'Pixel 4 XL', androidVersion: 'latest'}}
+        ]
+      }
+    }
+  },
+  vg: true,
+  test({eyes}) {
+    eyes.open({appName: 'Applitools Eyes SDK'})
+    eyes.check()
+    eyes.close()
+  },
+})
+
 // #endregion
 
 // #region CHECK FRAME

--- a/coverage-tests.js
+++ b/coverage-tests.js
@@ -314,6 +314,7 @@ test('check window UFG native', {
   test({eyes}) {
     eyes.open({appName: 'Applitools Eyes SDK'})
     eyes.check()
+    eyes.check()
     eyes.close()
   },
 })


### PR DESCRIPTION
There are 2 additions that need to be done for emitters and the actual SDK test code:
1. Support `injectUFGLib` in `env`. When set to true, the driver's capabilities should be added with the `processArguments` injection configuration (see below).
2. Add 2 new devices to the map of predefined devices: `iPhone 12` and `Pixel 3 XL`.

## Appendix:
Injection config:
```
{
  capabilities: {
    'appium:processArguments': {
      args: [],
      env: {
        DYLD_INSERT_LIBRARIES: '@executable_path/Frameworks/UFG_lib.xcframework/ios-arm64_x86_64-simulator/UFG_lib.framework/UFG_lib'
      }
    }
  }
}
```

iPhone 12 capabilities:
```
{
  platformName: 'iOS',
  'appium:platformVersion': '14.5',
  'appium:deviceName': 'iPhone 12 Simulator',
}
```

Pixel 3 XL capabilities:
```
{
  deviceName: 'Google Pixel 3 XL GoogleAPI Emulator',
  platformName: 'Android',
  platformVersion: '10.0',
  deviceOrientation: 'portrait',
}
```