### PR TITLE
add tests for window and region for landscape on Android 7 and 10

### DIFF
--- a/DotNet/overrides.js
+++ b/DotNet/overrides.js
@@ -85,4 +85,8 @@ module.exports = {
 	// TODO verify and enable
   'should send agentRunId': {skipEmit: true},
   "appium iOS nav bar check regio": {skipEmit: true},
+  'appium android landscape mode check window andorid 7': {skip: true},
+  'appium android landscape mode check region android 7': {skip: true},
+  'appium android landscape mode check window andorid 10': {skip: true},
+  'appium android landscape mode check region android 10': {skip: true}
 }

--- a/DotNet/overrides.js
+++ b/DotNet/overrides.js
@@ -85,8 +85,6 @@ module.exports = {
 	// TODO verify and enable
   'should send agentRunId': {skipEmit: true},
   "appium iOS nav bar check regio": {skipEmit: true},
-  "appium android landscape mode check window andorid 7": {skip: true},
-  "appium android landscape mode check region android 7": {skip: true},
-  "appium android landscape mode check window andorid 10": {skip: true},
-  "appium android landscape mode check region android 10": {skip: true}
+  "appium android landscape mode check window": {skip: true},
+  "appium android landscape mode check region": {skip: true},
 }

--- a/DotNet/overrides.js
+++ b/DotNet/overrides.js
@@ -85,8 +85,8 @@ module.exports = {
 	// TODO verify and enable
   'should send agentRunId': {skipEmit: true},
   "appium iOS nav bar check regio": {skipEmit: true},
-  'appium android landscape mode check window andorid 7': {skip: true},
-  'appium android landscape mode check region android 7': {skip: true},
-  'appium android landscape mode check window andorid 10': {skip: true},
-  'appium android landscape mode check region android 10': {skip: true}
+  "appium android landscape mode check window andorid 7": {skip: true},
+  "appium android landscape mode check region android 7": {skip: true},
+  "appium android landscape mode check window andorid 10": {skip: true},
+  "appium android landscape mode check region android 10": {skip: true}
 }

--- a/coverage-tests.js
+++ b/coverage-tests.js
@@ -2246,7 +2246,11 @@ test('appium iOS nav bar check region', {
   },
 })
 
-test('appium android landscape mode check window andorid 7', {
+test('appium android landscape mode check window', {
+  variants: {
+    'on android 7': {env: {device: 'Samsung Galaxy S8', app: 'https://applitools.jfrog.io/artifactory/Examples/eyes-android-hello-world.apk', orientation: 'landscape'}},
+    'on andorid 10': {env: {device: 'Pixel 3 XL', app: 'https://applitools.jfrog.io/artifactory/Examples/eyes-android-hello-world.apk', orientation: 'landscape'}}
+  },
   env: {device: 'Samsung Galaxy S8', app: 'https://applitools.jfrog.io/artifactory/Examples/eyes-android-hello-world.apk', orientation: 'landscape'},
   test: ({driver, eyes, helpers, assert}) => {
     eyes.open({appName: 'Applitools Eyes SDK'})
@@ -2254,7 +2258,11 @@ test('appium android landscape mode check window andorid 7', {
     const result = eyes.close()
   },
 })
-test('appium android landscape mode check region android 7', {
+test('appium android landscape mode check region', {
+  variants: {
+    'on android 7': {env: {device: 'Samsung Galaxy S8', app: 'https://applitools.jfrog.io/artifactory/Examples/eyes-android-hello-world.apk', orientation: 'landscape'}},
+    'on andorid 10': {env: {device: 'Pixel 3 XL', app: 'https://applitools.jfrog.io/artifactory/Examples/eyes-android-hello-world.apk', orientation: 'landscape'}}
+  },
   env: {device: 'Samsung Galaxy S8', app: 'https://applitools.jfrog.io/artifactory/Examples/eyes-android-hello-world.apk', orientation: 'landscape'},
   test: ({driver, eyes, helpers, assert}) => {
     eyes.open({appName: 'Applitools Eyes SDK'})
@@ -2262,20 +2270,5 @@ test('appium android landscape mode check region android 7', {
     const result = eyes.close()
   },
 })
-test('appium android landscape mode check window andorid 10', {
-  env: {device: 'Pixel 3 XL', app: 'https://applitools.jfrog.io/artifactory/Examples/eyes-android-hello-world.apk', orientation: 'landscape'},
-  test: ({driver, eyes, helpers, assert}) => {
-    eyes.open({appName: 'Applitools Eyes SDK'})
-    eyes.check({isFully: false})
-    const result = eyes.close()
-  },
-})
-test('appium android landscape mode check region android 10', {
-  env: {device: 'Pixel 3 XL', app: 'https://applitools.jfrog.io/artifactory/Examples/eyes-android-hello-world.apk', orientation: 'landscape'},
-  test: ({driver, eyes, helpers, assert}) => {
-    eyes.open({appName: 'Applitools Eyes SDK'})
-    eyes.check({region: {type: TYPE.XPATH, selector: '//android.widget.CheckBox[1]'}, isFully: false})
-    const result = eyes.close()
-  },
-})
+
 // #endregion

--- a/coverage-tests.js
+++ b/coverage-tests.js
@@ -2245,4 +2245,37 @@ test('appium iOS nav bar check region', {
     const result = eyes.close()
   },
 })
+
+test('appium android landscape mode check window andorid 7', {
+  env: {device: 'Samsung Galaxy S8', app: 'https://applitools.jfrog.io/artifactory/Examples/eyes-android-hello-world.apk', orientation: 'landscape'},
+  test: ({driver, eyes, helpers, assert}) => {
+    eyes.open({appName: 'Applitools Eyes SDK'})
+    eyes.check({isFully: false})
+    const result = eyes.close()
+  },
+})
+test('appium android landscape mode check region android 7', {
+  env: {device: 'Samsung Galaxy S8', app: 'https://applitools.jfrog.io/artifactory/Examples/eyes-android-hello-world.apk', orientation: 'landscape'},
+  test: ({driver, eyes, helpers, assert}) => {
+    eyes.open({appName: 'Applitools Eyes SDK'})
+    eyes.check({region: {type: TYPE.XPATH, selector: '//android.widget.CheckBox[1]'}, isFully: false})
+    const result = eyes.close()
+  },
+})
+test('appium android landscape mode check window andorid 10', {
+  env: {device: 'Pixel 3 XL', app: 'https://applitools.jfrog.io/artifactory/Examples/eyes-android-hello-world.apk', orientation: 'landscape'},
+  test: ({driver, eyes, helpers, assert}) => {
+    eyes.open({appName: 'Applitools Eyes SDK'})
+    eyes.check({isFully: false})
+    const result = eyes.close()
+  },
+})
+test('appium android landscape mode check region android 10', {
+  env: {device: 'Pixel 3 XL', app: 'https://applitools.jfrog.io/artifactory/Examples/eyes-android-hello-world.apk', orientation: 'landscape'},
+  test: ({driver, eyes, helpers, assert}) => {
+    eyes.open({appName: 'Applitools Eyes SDK'})
+    eyes.check({region: {type: TYPE.XPATH, selector: '//android.widget.CheckBox[1]'}, isFully: false})
+    const result = eyes.close()
+  },
+})
 // #endregion

--- a/java/overrides.js
+++ b/java/overrides.js
@@ -57,10 +57,8 @@ module.exports = {
     
     // TODO Failed and needs to be re-checked.
     'appium iOS nav bar check region': {skip: true},
-    "appium android landscape mode check window andorid 7": {skip: true},
-    "appium android landscape mode check region android 7": {skip: true},
-    "appium android landscape mode check window andorid 10": {skip: true},
-    "appium android landscape mode check region android 10": {skip: true}
+    "appium android landscape mode check window": {skip: true},
+    "appium android landscape mode check region": {skip: true},
 
 
 }

--- a/java/overrides.js
+++ b/java/overrides.js
@@ -57,5 +57,10 @@ module.exports = {
     
     // TODO Failed and needs to be re-checked.
     'appium iOS nav bar check region': {skip: true},
+    'appium android landscape mode check window andorid 7': {skip: true},
+    'appium android landscape mode check region android 7': {skip: true},
+    'appium android landscape mode check window andorid 10': {skip: true},
+    'appium android landscape mode check region android 10': {skip: true}
+
 
 }

--- a/java/overrides.js
+++ b/java/overrides.js
@@ -57,10 +57,10 @@ module.exports = {
     
     // TODO Failed and needs to be re-checked.
     'appium iOS nav bar check region': {skip: true},
-    'appium android landscape mode check window andorid 7': {skip: true},
-    'appium android landscape mode check region android 7': {skip: true},
-    'appium android landscape mode check window andorid 10': {skip: true},
-    'appium android landscape mode check region android 10': {skip: true}
+    "appium android landscape mode check window andorid 7": {skip: true},
+    "appium android landscape mode check region android 7": {skip: true},
+    "appium android landscape mode check window andorid 10": {skip: true},
+    "appium android landscape mode check region android 10": {skip: true}
 
 
 }

--- a/python/overrides.js
+++ b/python/overrides.js
@@ -18,8 +18,8 @@ module.exports = {
     // TODO verify and enable
     'appium iOS check fully window with scroll and pageCoverage': { skipEmit: true },
     'appium iOS check window region with scroll and pageCoverage': { skipEmit: true },
-    'appium android landscape mode check window andorid 7': {skip: true},
-    'appium android landscape mode check region android 7': {skip: true},
-    'appium android landscape mode check window andorid 10': {skip: true},
-    'appium android landscape mode check region android 10': {skip: true}
+    "appium android landscape mode check window andorid 7": {skip: true},
+    "appium android landscape mode check region android 7": {skip: true},
+    "appium android landscape mode check window andorid 10": {skip: true},
+    "appium android landscape mode check region android 10": {skip: true}
 }

--- a/python/overrides.js
+++ b/python/overrides.js
@@ -18,8 +18,6 @@ module.exports = {
     // TODO verify and enable
     'appium iOS check fully window with scroll and pageCoverage': { skipEmit: true },
     'appium iOS check window region with scroll and pageCoverage': { skipEmit: true },
-    "appium android landscape mode check window andorid 7": {skip: true},
-    "appium android landscape mode check region android 7": {skip: true},
-    "appium android landscape mode check window andorid 10": {skip: true},
-    "appium android landscape mode check region android 10": {skip: true}
+    "appium android landscape mode check window": {skip: true},
+    "appium android landscape mode check region": {skip: true},
 }

--- a/python/overrides.js
+++ b/python/overrides.js
@@ -18,4 +18,8 @@ module.exports = {
     // TODO verify and enable
     'appium iOS check fully window with scroll and pageCoverage': { skipEmit: true },
     'appium iOS check window region with scroll and pageCoverage': { skipEmit: true },
+    'appium android landscape mode check window andorid 7': {skip: true},
+    'appium android landscape mode check region android 7': {skip: true},
+    'appium android landscape mode check window andorid 10': {skip: true},
+    'appium android landscape mode check region android 10': {skip: true}
 }

--- a/ruby/overrides.js
+++ b/ruby/overrides.js
@@ -48,8 +48,8 @@ module.exports = {
 
     // TODO verify and enable
     "appium iOS nav bar check regio": {skipEmit: true},
-    'appium android landscape mode check window andorid 7': {skip: true},
-    'appium android landscape mode check region android 7': {skip: true},
-    'appium android landscape mode check window andorid 10': {skip: true},
-    'appium android landscape mode check region android 10': {skip: true}
+    "appium android landscape mode check window andorid 7": {skip: true},
+    "appium android landscape mode check region android 7": {skip: true},
+    "appium android landscape mode check window andorid 10": {skip: true},
+    "appium android landscape mode check region android 10": {skip: true}
 }

--- a/ruby/overrides.js
+++ b/ruby/overrides.js
@@ -48,8 +48,6 @@ module.exports = {
 
     // TODO verify and enable
     "appium iOS nav bar check regio": {skipEmit: true},
-    "appium android landscape mode check window andorid 7": {skip: true},
-    "appium android landscape mode check region android 7": {skip: true},
-    "appium android landscape mode check window andorid 10": {skip: true},
-    "appium android landscape mode check region android 10": {skip: true}
+    "appium android landscape mode check window": {skip: true},
+    "appium android landscape mode check region": {skip: true},
 }

--- a/ruby/overrides.js
+++ b/ruby/overrides.js
@@ -45,5 +45,11 @@ module.exports = {
     'should waitBeforeCapture with breakpoints in check': { skipEmit: true },
     'should waitBeforeCapture with breakpoints in open': { skipEmit: true },
     'should be empty if page delayed by 1500': { skipEmit: true },
+
+    // TODO verify and enable
     "appium iOS nav bar check regio": {skipEmit: true},
+    'appium android landscape mode check window andorid 7': {skip: true},
+    'appium android landscape mode check region android 7': {skip: true},
+    'appium android landscape mode check window andorid 10': {skip: true},
+    'appium android landscape mode check region android 10': {skip: true}
 }


### PR DESCRIPTION
The reason I added the tests for both android 7 and 10 is that I noticed that on `Android` `7` and lower when we rotate the device to landscape the navbar is on the right and on `Android` `8` and above it's on the left.

I already ran the tests and accepted the [new baselines](https://eyes.applitools.com/app/test-results/00000251752428552488/?accountId=xIpd7EWjhU6cjJzDGrMcUw~~)