### PR TITLE
make sure exception in testResultsSummary include the relevant exception

### DIFF
--- a/DotNet/overrides.js
+++ b/DotNet/overrides.js
@@ -88,6 +88,7 @@ module.exports = {
   "appium android landscape mode check window": {skip: true},
   "appium android landscape mode check region": {skip: true},
   "should work with beforeCaptureScreenshot hook": {skip: true},
+  "Should return exception in TestResultsSummary": {skipEmit: true},
 
   // A new added test?
   "check window on mobile web android": {skipEmit: true}

--- a/coverage-tests.js
+++ b/coverage-tests.js
@@ -2044,8 +2044,6 @@ test('adopted styleSheets on firefox', {
     eyes.check({isFully: false, visualGridOptions: {polyfillAdoptedStyleSheets: true}})
     eyes.check({isFully: false, visualGridOptions: {polyfillAdoptedStyleSheets: false}})
     eyes.close()
-    const summary = eyes.runner.getAllTestResults(false)
-    assert.equal( summary.getAllResults()[0]._container.exception.message.substring(0,24), `failed to render screenshot`)
   }
 })
 
@@ -2287,6 +2285,27 @@ page: 'HelloWorld',
     eyes.open({appName: 'Applitools Eyes SDK'})
     eyes.check({isFully: true, hooks: {beforeCaptureScreenshot: `document.body.style.backgroundColor = 'gold'`}})
     eyes.close()
+  }
+})
+
+test('Should return exception in TestResultsSummary', {
+  page: 'AdoptedStyleSheets',
+  vg: true,
+  config: {
+    browsersInfo: [
+      {name: 'firefox', width: 640, height: 480},
+    ],
+  },
+  test({eyes, assert}) {
+    eyes.open({appName: 'Applitools Eyes SDK', viewportSize})
+    eyes.check({isFully: false})
+    assert.throws(() => void eyes.close())
+    // TODO assert test is aborted
+    eyes.open({appName: 'Applitools Eyes SDK', viewportSize})
+    eyes.check({isFully: false, visualGridOptions: {polyfillAdoptedStyleSheets: true}})
+    eyes.close(false)
+    const summary = eyes.runner.getAllTestResults(false)
+    assert.equal( summary.getAllResults()[0]._container.exception.message.substring(0,27), `failed to render screenshot`)
   }
 })
 

--- a/coverage-tests.js
+++ b/coverage-tests.js
@@ -2044,6 +2044,8 @@ test('adopted styleSheets on firefox', {
     eyes.check({isFully: false, visualGridOptions: {polyfillAdoptedStyleSheets: true}})
     eyes.check({isFully: false, visualGridOptions: {polyfillAdoptedStyleSheets: false}})
     eyes.close()
+    const summary = eyes.runner.getAllTestResults(false)
+    assert.equal( summary.getAllResults()[0]._container.exception.message.substring(0,24), `failed to render screenshot`)
   }
 })
 

--- a/coverage-tests.js
+++ b/coverage-tests.js
@@ -2300,10 +2300,6 @@ test('Should return exception in TestResultsSummary', {
     eyes.open({appName: 'Applitools Eyes SDK', viewportSize})
     eyes.check({isFully: false})
     assert.throws(() => void eyes.close())
-    // TODO assert test is aborted
-    eyes.open({appName: 'Applitools Eyes SDK', viewportSize})
-    eyes.check({isFully: false, visualGridOptions: {polyfillAdoptedStyleSheets: true}})
-    eyes.close(false)
     const summary = eyes.runner.getAllTestResults(false)
     assert.equal( summary.getAllResults()[0]._container.exception.message.substring(0,27), `failed to render screenshot`)
   }

--- a/java/overrides.js
+++ b/java/overrides.js
@@ -54,6 +54,7 @@ module.exports = {
     // TODO verify and enable
     'should send agentRunId': {skipEmit: true},
     "appium iOS nav bar check regio": {skipEmit: true},
+    "Should return exception in TestResultsSummary": {skipEmit: true},
     
     // TODO Failed and needs to be re-checked.
     'appium iOS nav bar check region': {skip: true},

--- a/python/overrides.js
+++ b/python/overrides.js
@@ -14,6 +14,7 @@ module.exports = {
     "appium android landscape mode check window on android 10": {skipEmit: true},
     "appium android landscape mode check region on android 7": {skipEmit: true},
     "appium android landscape mode check region on android 10": {skipEmit: true},
+    "Should return exception in TestResultsSummary": {skipEmit: true},
     // OCR is broken again
     "should extract text regions from image": {skip: true},
 }

--- a/ruby/overrides.js
+++ b/ruby/overrides.js
@@ -50,5 +50,6 @@ module.exports = {
     "appium iOS nav bar check regio": {skipEmit: true},
     "appium android landscape mode check window": {skip: true},
     "appium android landscape mode check region": {skip: true},
-    "should work with beforeCaptureScreenshot hook": {skip: true}
+    "should work with beforeCaptureScreenshot hook": {skip: true},
+    "Should return exception in TestResultsSummary": {skipEmit: true},
 }


### PR DESCRIPTION
I added an assertion that we get the exception that is thrown in this test to `TestResultsSummary`
This was reported [here](https://trello.com/c/WV7ixoDy/1325-universal-sdk-runtime-errors-in-closemanager-results-returned-as-empty-dicts) and fixed [here](https://github.com/applitools/eyes.sdk.javascript1/pull/878)