### PR TITLE
Fix wait before capture test

### DIFF
--- a/coverage-tests.js
+++ b/coverage-tests.js
@@ -2196,9 +2196,9 @@ test('should waitBeforeCapture in check', {
     eyes.open({ appName: 'Applitools Eyes SDK', viewportSize })
     eyes.check({name: "session opening is finished", isFully: false})
     // 'delay' (in queryString) is the time in milliseconds until image is visible in html (default is 1000)
-    driver.visit('https://applitools.github.io/demo/TestPages/waitBeforeCapture/dynamicDelay.html?delay=2000')
-    eyes.check({name: "should show smurf", isFully: true, waitBeforeCapture: 2500})
-    driver.visit('https://applitools.github.io/demo/TestPages/waitBeforeCapture/dynamicDelay.html?delay=2000')
+    driver.visit('https://applitools.github.io/demo/TestPages/waitBeforeCapture/dynamicDelay.html?delay=5000')
+    eyes.check({name: "should show smurf", isFully: true, waitBeforeCapture: 6000})
+    driver.visit('https://applitools.github.io/demo/TestPages/waitBeforeCapture/dynamicDelay.html?delay=5000')
     eyes.check({name: "should be blank", isFully: true})
     eyes.close()
   },

--- a/coverage-tests.js
+++ b/coverage-tests.js
@@ -2190,28 +2190,16 @@ test('should waitBeforeCapture in open', {
 })
 
 test('should waitBeforeCapture in check', {
+  page: 'Simple',
   vg: true,
   test({ driver, eyes }) {
+    eyes.open({ appName: 'Applitools Eyes SDK', viewportSize })
+    eyes.check({name: "session opening is finished", isFully: false})
     // 'delay' (in queryString) is the time in milliseconds until image is visible in html (default is 1000)
     driver.visit('https://applitools.github.io/demo/TestPages/waitBeforeCapture/dynamicDelay.html?delay=1000')
-    eyes.open({ appName: 'Applitools Eyes SDK', viewportSize })
-    eyes.check({
-      isFully: true,
-      waitBeforeCapture: 2000,
-    })
-    eyes.close()
-  },
-})
-
-test('should be empty if page delayed by 1500', {
-  vg: true,
-  test({ driver, eyes }) {
-    // 'delay' (in queryString) is the time in milliseconds until image is visible in html (default is 1000)
-    driver.visit('https://applitools.github.io/demo/TestPages/waitBeforeCapture/dynamicDelay.html?delay=1500')
-    eyes.open({ appName: 'Applitools Eyes SDK', viewportSize })
-    eyes.check({
-      isFully: true
-    })
+    eyes.check({name: "should be blank", isFully: true})
+    driver.visit('https://applitools.github.io/demo/TestPages/waitBeforeCapture/dynamicDelay.html?delay=1000')
+    eyes.check({name: "should show smurf", isFully: true, waitBeforeCapture: 2000})
     eyes.close()
   },
 })

--- a/coverage-tests.js
+++ b/coverage-tests.js
@@ -2197,9 +2197,9 @@ test('should waitBeforeCapture in check', {
     eyes.check({name: "session opening is finished", isFully: false})
     // 'delay' (in queryString) is the time in milliseconds until image is visible in html (default is 1000)
     driver.visit('https://applitools.github.io/demo/TestPages/waitBeforeCapture/dynamicDelay.html?delay=1000')
-    eyes.check({name: "should be blank", isFully: true})
-    driver.visit('https://applitools.github.io/demo/TestPages/waitBeforeCapture/dynamicDelay.html?delay=1000')
     eyes.check({name: "should show smurf", isFully: true, waitBeforeCapture: 2000})
+    driver.visit('https://applitools.github.io/demo/TestPages/waitBeforeCapture/dynamicDelay.html?delay=1000')
+    eyes.check({name: "should be blank", isFully: true})
     eyes.close()
   },
 })

--- a/coverage-tests.js
+++ b/coverage-tests.js
@@ -2196,9 +2196,9 @@ test('should waitBeforeCapture in check', {
     eyes.open({ appName: 'Applitools Eyes SDK', viewportSize })
     eyes.check({name: "session opening is finished", isFully: false})
     // 'delay' (in queryString) is the time in milliseconds until image is visible in html (default is 1000)
-    driver.visit('https://applitools.github.io/demo/TestPages/waitBeforeCapture/dynamicDelay.html?delay=1000')
-    eyes.check({name: "should show smurf", isFully: true, waitBeforeCapture: 2000})
-    driver.visit('https://applitools.github.io/demo/TestPages/waitBeforeCapture/dynamicDelay.html?delay=1000')
+    driver.visit('https://applitools.github.io/demo/TestPages/waitBeforeCapture/dynamicDelay.html?delay=2000')
+    eyes.check({name: "should show smurf", isFully: true, waitBeforeCapture: 2500})
+    driver.visit('https://applitools.github.io/demo/TestPages/waitBeforeCapture/dynamicDelay.html?delay=2000')
     eyes.check({name: "should be blank", isFully: true})
     eyes.close()
   },

--- a/python/parser.js
+++ b/python/parser.js
@@ -4,10 +4,10 @@ const types = require('./mapping/types')
 const selectors = require('./mapping/selectors')
 
 function checkSettings(cs) {
-    let name = `'', `
+    let name = ''
     let target = `Target`
     if(cs === undefined){
-        return name + target + '.window()'
+        return target + '.window()'
     }
     let element = ''
     let options = ''
@@ -31,7 +31,7 @@ function checkSettings(cs) {
     if (cs.matchLevel) options += `.match_level(MatchLevel.${cs.matchLevel.toUpperCase()})`
     if (cs.hooks) options += handleHooks(cs.hooks)
     if (cs.isFully !== undefined) options += `.fully(${capitalizeFirstLetter(cs.isFully)})`
-    if (cs.name) options += `.with_name(${cs.name})`
+    if (cs.name) name = python`${cs.name}, `
     if (cs.waitBeforeCapture) options += `.wait_before_capture(${cs.waitBeforeCapture})`
     return name + target + element + options
 }


### PR DESCRIPTION
The original `should be empty if page delayed by 1500` is failing when eyes server throttles eyes.open calls in highly paralleled suite. This change is to take eyes.open call out of the delay measurement so the test is not affected by the server performance.

I merged two tests `should waitBeforeCapture in check` and `should be empty if page delayed by 1500` into one because that better reflects the purpose of `should be empty if page delayed by 1500` to my opinion - to catch _false positive_ results in `should waitBeforeCapture in check`. Being separate test in it's current form, `should be empty if page delayed by 1500` looks like a _performance test_ for eyes.open + eyes.check calls and I believe this test suite is NOT performance test suite, because it is being run in various environments and that makes performance testing results non comparable and useless. Having both checks in one test is way more explanatory to the check purpose.