### PR TITLE
Update coverage-tests.js

### DIFF
--- a/coverage-tests.js
+++ b/coverage-tests.js
@@ -866,31 +866,16 @@ test('should send ignore region by selector', {
   variants: {
     'with css stitching': {config: {stitchMode: 'CSS', baselineName: 'TestCheckWindowWithIgnoreBySelector_Fluent'}},
     'with scroll stitching': {config: {stitchMode: 'Scroll', baselineName: 'TestCheckWindowWithIgnoreBySelector_Fluent_Scroll'}},
+    'with vg': {vg: true, config: { baselineName: 'TestCheckWindowWithIgnoreBySelector_Fluent_VG'}},
   },
-  test({eyes, assert, helpers}) {
+  test({eyes, assert, helpers, config}) {
     eyes.open({appName: 'Eyes Selenium SDK - Fluent API', viewportSize})
     eyes.check({ignoreRegions: ['#overflowing-div'], isFully: false})
     const result = eyes.close()
     const info = helpers.getTestInfo(result)
     assert.equal(
       info.actualAppOutput[0].imageMatchSettings.ignore[0],
-      {left: 8, top: 81, width: 304, height: 184},
-    )
-  },
-})
-
-test('should send ignore region by selector with vg', {
-  page: 'Default',
-  vg: true,
-  config: {baselineName: 'TestCheckWindowWithIgnoreBySelector_Fluent_VG'},
-  test({eyes, assert, helpers}) {
-    eyes.open({appName: 'Eyes Selenium SDK - Fluent API', viewportSize})
-    eyes.check({ignoreRegions: ['#overflowing-div'], isFully: false})
-    const result = eyes.close()
-    const info = helpers.getTestInfo(result)
-    assert.equal(
-      info.actualAppOutput[0].imageMatchSettings.ignore[0],
-      {left: 8, top: 80, width: 304, height: 185},
+      {left: 8, top: config.visualgrid ? 80 : 81, width: 304, height: config.visualgrid ? 185 : 184},
     )
   },
 })
@@ -900,38 +885,18 @@ test('should send ignore regions by selector', {
   variants: {
     'with css stitching': {config: {stitchMode: 'CSS', baselineName: 'TestCheckFullWindowWithMultipleIgnoreRegionsBySelector_Fluent'}},
     'with scroll stitching': {config: {stitchMode: 'Scroll', baselineName: 'TestCheckFullWindowWithMultipleIgnoreRegionsBySelector_Fluent_Scroll'}},
+    'with vg': {vg: true, config: {baselineName: 'TestCheckFullWindowWithMultipleIgnoreRegionsBySelector_Fluent_VG'}},
   },
-  test({eyes, assert, helpers}) {
+  test({eyes, assert, helpers, config}) {
     eyes.open({appName: 'Eyes Selenium SDK - Fluent API', viewportSize})
     eyes.check({ignoreRegions: ['.ignore'], isFully: true})
     const result = eyes.close()
     const info = helpers.getTestInfo(result)
     const imageMatchSettings = info.actualAppOutput[0].imageMatchSettings
     const expectedIgnoreRegions = [
-      {left: 10, top: 286, width: 800, height: 500},
-      {left: 122, top: 933, width: 456, height: 306},
-      {left: 8, top: 1277, width: 690, height: 206},
-    ]
-    for (const [index, expectedIgnoreRegion] of expectedIgnoreRegions.entries()) {
-      assert.equal(imageMatchSettings.ignore[index], expectedIgnoreRegion)
-    }
-  },
-})
-
-test('should send ignore regions by selector with vg', {
-  page: 'Default',
-  vg: true,
-  config: {baselineName: 'TestCheckFullWindowWithMultipleIgnoreRegionsBySelector_Fluent_VG'},
-  test({eyes, assert, helpers}) {
-    eyes.open({appName: 'Eyes Selenium SDK - Fluent API', viewportSize})
-    eyes.check({ignoreRegions: ['.ignore'], isFully: true})
-    const result = eyes.close()
-    const info = helpers.getTestInfo(result)
-    const imageMatchSettings = info.actualAppOutput[0].imageMatchSettings
-    const expectedIgnoreRegions = [
-      {left: 10, top: 285, width: 800, height: 501},
-      {left: 122, top: 932, width: 456, height: 307},
-      {left: 8, top: 1276, width: 690, height: 207},
+      {left: 10, top: config.visualgrid ? 285 : 286, width: 800, height: config.visualgrid ? 501 : 500},
+      {left: 122, top: config.visualgrid ? 932 : 933, width: 456, height: config.visualgrid ? 307 : 306},
+      {left: 8, top: config.visualgrid ? 1276 : 1277, width: 690, height: config.visualgrid ? 207 : 206},
     ]
     for (const [index, expectedIgnoreRegion] of expectedIgnoreRegions.entries()) {
       assert.equal(imageMatchSettings.ignore[index], expectedIgnoreRegion)
@@ -963,31 +928,16 @@ test('should send ignore region by the same selector as target region', {
   variants: {
     'with css stitching': {config: {stitchMode: 'CSS', baselineName: 'TestCheckElementWithIgnoreRegionBySameElement_Fluent'}},
     'with scroll stitching': {config: {stitchMode: 'Scroll', baselineName: 'TestCheckElementWithIgnoreRegionBySameElement_Fluent_Scroll'}},
+    'with vg': {vg: true, config: {baselineName: 'TestCheckElementWithIgnoreRegionBySameElement_Fluent_VG'}},
   },
-  test({eyes, assert, helpers}) {
+  test({eyes, assert, helpers, config}) {
     eyes.open({appName: 'Eyes Selenium SDK - Fluent API', viewportSize})
     eyes.check({region: '#overflowing-div-image', ignoreRegions: ['#overflowing-div-image']})
     const result = eyes.close()
     const info = helpers.getTestInfo(result)
     assert.equal(
       info.actualAppOutput[0].imageMatchSettings.ignore[0],
-      {left: 0, top: 0, width: 304, height: 184},
-    )
-  },
-})
-
-test('should send ignore region by the same selector as target region with vg', {
-  page: 'Default',
-  vg: true,
-  config: {baselineName: 'TestCheckElementWithIgnoreRegionBySameElement_Fluent_VG'},
-  test({eyes, assert, helpers}) {
-    eyes.open({appName: 'Eyes Selenium SDK - Fluent API', viewportSize})
-    eyes.check({region: '#overflowing-div-image', ignoreRegions: ['#overflowing-div-image']})
-    const result = eyes.close()
-    const info = helpers.getTestInfo(result)
-    assert.equal(
-      info.actualAppOutput[0].imageMatchSettings.ignore[0],
-      {left: 0, top: 0, width: 304, height: 185},
+      {left: 0, top: 0, width: 304, height: config.visualgrid ? 185 : 184},
     )
   },
 })
@@ -1054,8 +1004,9 @@ test('should send floating region by selector', {
   variants: {
     'with css stitching': {config: {stitchMode: 'CSS', baselineName: 'TestCheckWindowWithFloatingBySelector_Fluent'}},
     'with scroll stitching': {config: {stitchMode: 'Scroll', baselineName: 'TestCheckWindowWithFloatingBySelector_Fluent_Scroll'}},
+    'with vg': {vg: true, config: {baselineName: 'TestCheckWindowWithFloatingBySelector_Fluent_VG'}}
   },
-  test({eyes, assert, helpers}) {
+  test({eyes, assert, helpers, config}) {
     eyes.open({appName: 'Eyes Selenium SDK - Fluent API', viewportSize})
     eyes.check({
       floatingRegions: [
@@ -1073,34 +1024,7 @@ test('should send floating region by selector', {
     const info = helpers.getTestInfo(result)
     assert.equal(
       info.actualAppOutput[0].imageMatchSettings.floating[0],
-      {left: 8, top: 81, width: 304, height: 184, maxUpOffset: 3, maxDownOffset: 3, maxLeftOffset: 20, maxRightOffset: 30},
-    )
-  },
-})
-
-test('should send floating region by selector with vg', {
-  page: 'Default',
-  vg: true,
-  config: {baselineName: 'TestCheckWindowWithFloatingBySelector_Fluent_VG'},
-  test({eyes, assert, helpers}) {
-    eyes.open({appName: 'Eyes Selenium SDK - Fluent API', viewportSize})
-    eyes.check({
-      floatingRegions: [
-        {
-          region: '#overflowing-div',
-          maxUpOffset: 3,
-          maxDownOffset: 3,
-          maxLeftOffset: 20,
-          maxRightOffset: 30,
-        },
-      ],
-      isFully: false,
-    })
-    const result = eyes.close()
-    const info = helpers.getTestInfo(result)
-    assert.equal(
-      info.actualAppOutput[0].imageMatchSettings.floating[0],
-      {left: 8, top: 80, width: 304, height: 185, maxUpOffset: 3, maxDownOffset: 3, maxLeftOffset: 20, maxRightOffset: 30},
+      {left: 8, top: config.visualgrid ? 80 : 81, width: 304, height: config.visualgrid ? 185 : 184, maxUpOffset: 3, maxDownOffset: 3, maxLeftOffset: 20, maxRightOffset: 30},
     )
   },
 })
@@ -1147,8 +1071,17 @@ test('should send accessibility regions by selector', {
   variants: {
     'with css stitching': {config: {stitchMode: 'CSS', baselineName: 'TestAccessibilityRegions'}},
     'with scroll stitching': {config: {stitchMode: 'Scroll', baselineName: 'TestAccessibilityRegions_Scroll'}},
+    'with vg': {
+      vg: true, 
+      config: {
+        baselineName: 'TestAccessibilityRegions_VG',
+        defaultMatchSettings: {
+          accessibilitySettings: { level: 'AAA', guidelinesVersion: 'WCAG_2_0' }
+        }
+      }
+    }
   },
-  test({eyes, assert, helpers}) {
+  test({eyes, assert, helpers, config}) {
     eyes.open({appName: 'Eyes Selenium SDK - Fluent API', viewportSize})
     eyes.check({
       accessibilityRegions: [{region: '.ignore', type: 'LargeText'}],
@@ -1160,40 +1093,9 @@ test('should send accessibility regions by selector', {
     assert.equal(imageMatchSettings.accessibilitySettings.level, 'AAA')
     assert.equal(imageMatchSettings.accessibilitySettings.version, 'WCAG_2_0')
     const expectedAccessibilityRegions = [
-      {isDisabled: false, type: 'LargeText', left: 10, top: 286, width: 800, height: 500},
-      {isDisabled: false, type: 'LargeText', left: 122, top: 933, width: 456, height: 306},
-      {isDisabled: false, type: 'LargeText', left: 8, top: 1277, width: 690, height: 206},
-    ]
-    for (const [index, expectedAccessibilityRegion] of expectedAccessibilityRegions.entries()) {
-      assert.equal(imageMatchSettings.accessibility[index], expectedAccessibilityRegion)
-    }
-  }
-})
-
-test('should send accessibility regions by selector with vg', {
-  page: 'Default',
-  vg: true,
-  config: {
-    baselineName: 'TestAccessibilityRegions_VG',
-    defaultMatchSettings: {
-      accessibilitySettings: {level: 'AAA', guidelinesVersion: 'WCAG_2_0'}
-    }
-  },
-  test({eyes, assert, helpers}) {
-    eyes.open({appName: 'Eyes Selenium SDK - Fluent API', viewportSize})
-    eyes.check({
-      accessibilityRegions: [{region: '.ignore', type: 'LargeText'}],
-      isFully: false,
-    })
-    const result = eyes.close()
-    const info = helpers.getTestInfo(result)
-    const imageMatchSettings = info.actualAppOutput[0].imageMatchSettings
-    assert.equal(imageMatchSettings.accessibilitySettings.level, 'AAA')
-    assert.equal(imageMatchSettings.accessibilitySettings.version, 'WCAG_2_0')
-    const expectedAccessibilityRegions = [
-      {isDisabled: false, type: 'LargeText', left: 10, top: 285, width: 800, height: 501},
-      {isDisabled: false, type: 'LargeText', left: 122, top: 932, width: 456, height: 307},
-      {isDisabled: false, type: 'LargeText', left: 8, top: 1276, width: 690, height: 207},
+      {isDisabled: false, type: 'LargeText', left: 10, top: config.visualgrid ? 285 : 286, width: 800, height: config.visualgrid ? 501 : 500},
+      {isDisabled: false, type: 'LargeText', left: 122, top: config.visualgrid ? 932 : 933, width: 456, height: config.visualgrid ? 307 : 306},
+      {isDisabled: false, type: 'LargeText', left: 8, top: config.visualgrid ? 1276 : 1277, width: 690, height: config.visualgrid ? 207 : 206},
     ]
     for (const [index, expectedAccessibilityRegion] of expectedAccessibilityRegions.entries()) {
       assert.equal(imageMatchSettings.accessibility[index], expectedAccessibilityRegion)
@@ -1711,7 +1613,11 @@ test('should not check if disabled', {
 
 test('pageCoverage data is correct', {
   page: 'Simple',
-  test({ eyes, assert, helpers }) {
+  variants: {
+    '': { vg: false },
+    'with vg': { vg: true },
+  },
+  test({ eyes, assert, helpers, config }) {
     eyes.open({ appName: 'Applitools Eyes SDK', viewportSize });
     eyes.check({ isFully: true, pageId: 'my-page' });
     eyes.check({ isFully: true, region: '#overflowing-div > img:nth-child(22)', pageId: 'my-page' });
@@ -1736,44 +1642,7 @@ test('pageCoverage data is correct', {
     )
     assert.equal(
         info.actualAppOutput[1].pageCoverageInfo.imagePositionInPage,
-        {x:  636, y:  1292}, 'Selector match'
-    )
-    assert.equal(
-        info.actualAppOutput[2].pageCoverageInfo.imagePositionInPage,
-        {x: 10, y: 15}, 'Region match'
-    )
-  },
-});
-
-test('pageCoverage data is correct with vg', {
-  page: 'Simple',
-  vg: true,
-  test({ eyes, assert, helpers }) {
-    eyes.open({ appName: 'Applitools Eyes SDK', viewportSize });
-    eyes.check({ isFully: true, pageId: 'my-page' });
-    eyes.check({ isFully: true, region: '#overflowing-div > img:nth-child(22)', pageId: 'my-page' });
-    eyes.check({ isFully: true, region: {width: 200, height: 150, left: 10, top: 15}, pageId: 'my-page1' });
-    const result = eyes.close(false);
-    const info = helpers.getTestInfo(result);
-    assert.equal(
-        info.actualAppOutput[0].pageCoverageInfo.pageId,
-        'my-page', 'pageId match'
-    )
-    assert.equal(
-        info.actualAppOutput[0].pageCoverageInfo.width,
-        958, 'Page width match'
-    )
-    assert.equal(
-        info.actualAppOutput[0].pageCoverageInfo.height,
-        3540, 'Page height match'
-    )
-    assert.equal(
-        info.actualAppOutput[0].pageCoverageInfo.imagePositionInPage,
-        {x: 0, y: 0}, 'Full page'
-    )
-    assert.equal(
-        info.actualAppOutput[1].pageCoverageInfo.imagePositionInPage,
-        {x: 641 , y:  1297 }, 'Selector match'
+        {x:  config.visualgrid ? 641 : 636, y:  config.visualgrid ? 1297 : 1292}, 'Selector match'
     )
     assert.equal(
         info.actualAppOutput[2].pageCoverageInfo.imagePositionInPage,

--- a/coverage-tests.js
+++ b/coverage-tests.js
@@ -869,14 +869,14 @@ test('should send ignore region by selector', {
     'with scroll stitching': {config: {stitchMode: 'Scroll', baselineName: 'TestCheckWindowWithIgnoreBySelector_Fluent_Scroll'}},
     'with vg': {vg: true, config: { baselineName: 'TestCheckWindowWithIgnoreBySelector_Fluent_VG'}},
   },
-  test({eyes, assert, helpers, config}) {
+  test({eyes, assert, helpers, vg}) {
     eyes.open({appName: 'Eyes Selenium SDK - Fluent API', viewportSize})
     eyes.check({ignoreRegions: ['#overflowing-div'], isFully: false})
     const result = eyes.close()
     const info = helpers.getTestInfo(result)
     assert.equal(
       info.actualAppOutput[0].imageMatchSettings.ignore[0],
-      {left: 8, top: config.visualgrid ? 80 : 81, width: 304, height: config.visualgrid ? 185 : 184},
+      { left: 8, top: vg ? 80 : 81, width: 304, height: vg ? 185 : 184},
     )
   },
 })
@@ -888,16 +888,16 @@ test('should send ignore regions by selector', {
     'with scroll stitching': {config: {stitchMode: 'Scroll', baselineName: 'TestCheckFullWindowWithMultipleIgnoreRegionsBySelector_Fluent_Scroll'}},
     'with vg': {vg: true, config: {baselineName: 'TestCheckFullWindowWithMultipleIgnoreRegionsBySelector_Fluent_VG'}},
   },
-  test({eyes, assert, helpers, config}) {
+  test({eyes, assert, helpers, vg}) {
     eyes.open({appName: 'Eyes Selenium SDK - Fluent API', viewportSize})
     eyes.check({ignoreRegions: ['.ignore'], isFully: true})
     const result = eyes.close()
     const info = helpers.getTestInfo(result)
     const imageMatchSettings = info.actualAppOutput[0].imageMatchSettings
     const expectedIgnoreRegions = [
-      {left: 10, top: config.visualgrid ? 285 : 286, width: 800, height: config.visualgrid ? 501 : 500},
-      {left: 122, top: config.visualgrid ? 932 : 933, width: 456, height: config.visualgrid ? 307 : 306},
-      {left: 8, top: config.visualgrid ? 1276 : 1277, width: 690, height: config.visualgrid ? 207 : 206},
+      {left: 10, top: vg ? 285 : 286, width: 800, height: vg ? 501 : 500},
+      {left: 122, top: vg ? 932 : 933, width: 456, height: vg ? 307 : 306},
+      {left: 8, top: vg ? 1276 : 1277, width: 690, height: vg ? 207 : 206},
     ]
     for (const [index, expectedIgnoreRegion] of expectedIgnoreRegions.entries()) {
       assert.equal(imageMatchSettings.ignore[index], expectedIgnoreRegion)
@@ -931,14 +931,14 @@ test('should send ignore region by the same selector as target region', {
     'with scroll stitching': {config: {stitchMode: 'Scroll', baselineName: 'TestCheckElementWithIgnoreRegionBySameElement_Fluent_Scroll'}},
     'with vg': {vg: true, config: {baselineName: 'TestCheckElementWithIgnoreRegionBySameElement_Fluent_VG'}},
   },
-  test({eyes, assert, helpers, config}) {
+  test({eyes, assert, helpers, vg}) {
     eyes.open({appName: 'Eyes Selenium SDK - Fluent API', viewportSize})
     eyes.check({region: '#overflowing-div-image', ignoreRegions: ['#overflowing-div-image']})
     const result = eyes.close()
     const info = helpers.getTestInfo(result)
     assert.equal(
       info.actualAppOutput[0].imageMatchSettings.ignore[0],
-      {left: 0, top: 0, width: 304, height: config.visualgrid ? 185 : 184},
+      {left: 0, top: 0, width: 304, height: vg ? 185 : 184},
     )
   },
 })
@@ -1007,7 +1007,7 @@ test('should send floating region by selector', {
     'with scroll stitching': {config: {stitchMode: 'Scroll', baselineName: 'TestCheckWindowWithFloatingBySelector_Fluent_Scroll'}},
     'with vg': {vg: true, config: {baselineName: 'TestCheckWindowWithFloatingBySelector_Fluent_VG'}}
   },
-  test({eyes, assert, helpers, config}) {
+  test({eyes, assert, helpers, vg}) {
     eyes.open({appName: 'Eyes Selenium SDK - Fluent API', viewportSize})
     eyes.check({
       floatingRegions: [
@@ -1025,7 +1025,7 @@ test('should send floating region by selector', {
     const info = helpers.getTestInfo(result)
     assert.equal(
       info.actualAppOutput[0].imageMatchSettings.floating[0],
-      {left: 8, top: config.visualgrid ? 80 : 81, width: 304, height: config.visualgrid ? 185 : 184, maxUpOffset: 3, maxDownOffset: 3, maxLeftOffset: 20, maxRightOffset: 30},
+      {left: 8, top: vg ? 80 : 81, width: 304, height: vg ? 185 : 184, maxUpOffset: 3, maxDownOffset: 3, maxLeftOffset: 20, maxRightOffset: 30},
     )
   },
 })
@@ -1082,7 +1082,7 @@ test('should send accessibility regions by selector', {
       }
     }
   },
-  test({eyes, assert, helpers, config}) {
+  test({eyes, assert, helpers, vg}) {
     eyes.open({appName: 'Eyes Selenium SDK - Fluent API', viewportSize})
     eyes.check({
       accessibilityRegions: [{region: '.ignore', type: 'LargeText'}],
@@ -1094,9 +1094,9 @@ test('should send accessibility regions by selector', {
     assert.equal(imageMatchSettings.accessibilitySettings.level, 'AAA')
     assert.equal(imageMatchSettings.accessibilitySettings.version, 'WCAG_2_0')
     const expectedAccessibilityRegions = [
-      {isDisabled: false, type: 'LargeText', left: 10, top: config.visualgrid ? 285 : 286, width: 800, height: config.visualgrid ? 501 : 500},
-      {isDisabled: false, type: 'LargeText', left: 122, top: config.visualgrid ? 932 : 933, width: 456, height: config.visualgrid ? 307 : 306},
-      {isDisabled: false, type: 'LargeText', left: 8, top: config.visualgrid ? 1276 : 1277, width: 690, height: config.visualgrid ? 207 : 206},
+      {isDisabled: false, type: 'LargeText', left: 10, top: vg ? 285 : 286, width: 800, height: vg ? 501 : 500},
+      {isDisabled: false, type: 'LargeText', left: 122, top: vg ? 932 : 933, width: 456, height: vg ? 307 : 306},
+      {isDisabled: false, type: 'LargeText', left: 8, top: vg ? 1276 : 1277, width: 690, height: vg ? 207 : 206},
     ]
     for (const [index, expectedAccessibilityRegion] of expectedAccessibilityRegions.entries()) {
       assert.equal(imageMatchSettings.accessibility[index], expectedAccessibilityRegion)
@@ -1618,7 +1618,7 @@ test('pageCoverage data is correct', {
     '': { vg: false },
     'with vg': { vg: true },
   },
-  test({ eyes, assert, helpers, config }) {
+  test({ eyes, assert, helpers, vg}) {
     eyes.open({ appName: 'Applitools Eyes SDK', viewportSize });
     eyes.check({ isFully: true, pageId: 'my-page' });
     eyes.check({ isFully: true, region: '#overflowing-div > img:nth-child(22)', pageId: 'my-page' });
@@ -1643,7 +1643,7 @@ test('pageCoverage data is correct', {
     )
     assert.equal(
         info.actualAppOutput[1].pageCoverageInfo.imagePositionInPage,
-        {x:  config.visualgrid ? 641 : 636, y:  config.visualgrid ? 1297 : 1292}, 'Selector match'
+        {x:  vg ? 641 : 636, y:  vg ? 1297 : 1292}, 'Selector match'
     )
     assert.equal(
         info.actualAppOutput[2].pageCoverageInfo.imagePositionInPage,


### PR DESCRIPTION
`sdk-coverage-tests` package was recently updated with ability to expose an additional Boolean for 'visualgrid', this allows the `assert` section of each test in GCT to identify the test is a VG and change values accordingly.
There is a known issue that in some cases the expected result `height` and/or `top` values have a single pixel diff between VG vs. non-VG, the fast solution from GCT side is to duplicate the test (source code), set the test as `vg: true` and change the expected result pixels, the better solution is adding a `vg: true` variation to same test, **now it's possible**.
for example: in 'should send ignore region by the same selector as target region'
the assert is now:
`{left: 0, top: 0, width: 304, height: **config.visualgrid** ? 185 : 184}`

### What is actually happening:
Once tests are being generated, the result file contains the relevant value only, so if we take the example above:
- test file for VG 
  name: `ShouldSendIgnoreRegionByTheSameSelectorAsTargetRegionWithVg.spec.js` (same as before)
  and assert: `{left: 0, top: 0, width: 304, height: **185**}`
- test file for Classic 
  name: `ShouldSendIgnoreRegionByTheSameSelectorAsTargetRegionWithScrollStitching.spec.js` (same as before)
  and assert: `{left: 0, top: 0, width: 304, height: **184**}`

Adding this parameter allowed to unite 6 duplicated tests, the generated tests list is the same, it saved about 200 lines of code and double maintenance (and will be useful for any new added test)