### PR TITLE
Implement python emitters for padded ignore/content/strict/layout regions

### DIFF
--- a/python/overrides.js
+++ b/python/overrides.js
@@ -7,7 +7,4 @@ module.exports = {
     'should handle check of stale element in frame if selector is preserved': {skip: true},
 
     "Should return exception in TestResultsSummary": {skipEmit: true},
-    
-    "should use regions padding": {skipEmit: true},
-    "should use regions padding with vg": {skipEmit: true},
 }

--- a/python/overrides.js
+++ b/python/overrides.js
@@ -10,7 +10,4 @@ module.exports = {
     
     "should use regions padding": {skipEmit: true},
     "should use regions padding with vg": {skipEmit: true},
-
-    "should send codded regions with region id": {skipEmit: true},
-    "should send codded regions with region id with vg": {skipEmit: true},
 }

--- a/python/parser.js
+++ b/python/parser.js
@@ -18,10 +18,12 @@ function checkSettings(cs) {
         if (cs.frames) element += frames(cs.frames)
         if (cs.region) element += region(cs.region, true)
     }
-    if (cs.ignoreRegions) options += ignoreRegions(cs.ignoreRegions)
     if (cs.floatingRegions) options += floatingRegions(cs.floatingRegions)
     if (cs.accessibilityRegions) options += accessibilityRegions(cs.accessibilityRegions)
-    if (cs.layoutRegions) options += layoutRegions(cs.layoutRegions)
+    if (cs.ignoreRegions) options += regions("ignore", cs.ignoreRegions)
+    if (cs.layoutRegions) options += regions("layout", cs.layoutRegions)
+    if (cs.contentRegions) options += regions("content", cs.contentRegions)
+    if (cs.strictRegions) options += regions("strict", cs.strictRegions)
     if (cs.layoutBreakpoints) options += layoutBreakpoints(cs.layoutBreakpoints)
     if (cs.scrollRootElement) options += `.scroll_root_element(${printSelector(cs.scrollRootElement)})`
     if (cs.ignoreDisplacements) options += `.ignore_displacements(${capitalizeFirstLetter(cs.ignoreDisplacements)})`
@@ -93,11 +95,8 @@ function region(region_param, first_call) {
     }
 }
 
-function ignoreRegions(arr) {
-    return arr.reduce((acc, val) => `${acc}.ignore(${regionParameter(val)})`, '')
-}
-function layoutRegions(arr){
-    return arr.reduce((acc, val) => `${acc}.layout(${regionParameter(val)})`, '')
+function regions(kind, arr) {
+    return arr.reduce((acc, val) => `${acc}.${kind}(${regionParameter(val)})`, '')
 }
 function layoutBreakpoints(arg){
     if (Array.isArray(arg)) {
@@ -136,7 +135,13 @@ function regionParameter(region) {
             string = `${JSON.stringify(region)}`
             break;
         case "object":
-            string = parseObject(region.type ? region : (region.shadow ? region : {value: region, type:'Region'}))
+            if (region.region) {
+                string = python`${region.region}, padding=${region.padding}`
+            } else {
+                string = parseObject(
+                    region.type ? region : (region.shadow ? region : {value: region, type:'Region'})
+                )
+            }
             break;
         case "undefined":
             string = 'None'

--- a/python/parser.js
+++ b/python/parser.js
@@ -20,10 +20,10 @@ function checkSettings(cs) {
     }
     if (cs.floatingRegions) options += floatingRegions(cs.floatingRegions)
     if (cs.accessibilityRegions) options += accessibilityRegions(cs.accessibilityRegions)
-    if (cs.ignoreRegions) {options += regions("ignore", cs.ignoreRegions)}
-    if (cs.layoutRegions) {options += regions("layout", cs.layoutRegions)}
-    if (cs.contentRegions) {options += regions("content", cs.contentRegions)}
-    if (cs.strictRegions) {options += regions("strict", cs.strictRegions)}
+    if (cs.ignoreRegions) {options += regions("ignore", cs.ignoreRegions);}
+    if (cs.layoutRegions) {options += regions("layout", cs.layoutRegions);}
+    if (cs.contentRegions) {options += regions("content", cs.contentRegions);}
+    if (cs.strictRegions) {options += regions("strict", cs.strictRegions);}
     if (cs.layoutBreakpoints) options += layoutBreakpoints(cs.layoutBreakpoints)
     if (cs.scrollRootElement) options += `.scroll_root_element(${printSelector(cs.scrollRootElement)})`
     if (cs.ignoreDisplacements) options += `.ignore_displacements(${capitalizeFirstLetter(cs.ignoreDisplacements)})`

--- a/python/parser.js
+++ b/python/parser.js
@@ -21,7 +21,7 @@ function checkSettings(cs) {
     if (cs.floatingRegions) options += floatingRegions(cs.floatingRegions)
     if (cs.accessibilityRegions) options += accessibilityRegions(cs.accessibilityRegions)
     if (cs.ignoreRegions) {options += regions("ignore", cs.ignoreRegions)}
-    if (cs.layoutRegions) options += regions("layout", cs.layoutRegions)
+    if (cs.layoutRegions) {options += regions("layout", cs.layoutRegions)}
     if (cs.contentRegions) {options += regions("content", cs.contentRegions)}
     if (cs.strictRegions) {options += regions("strict", cs.strictRegions)}
     if (cs.layoutBreakpoints) options += layoutBreakpoints(cs.layoutBreakpoints)

--- a/python/parser.js
+++ b/python/parser.js
@@ -136,7 +136,13 @@ function regionParameter(region) {
             break;
         case "object":
             if (region.region) {
-                string = python`${region.region}, padding=${region.padding}`;
+                string = python`${region.region}`;
+                if (region.padding) {
+                    string += python`, padding=${region.padding}`;
+                }
+                if (region.regionId) {
+                    string += python`, region_id=${region.regionId}`;
+                }
             } else {
                 string = parseObject(
                     region.type ? region : (region.shadow ? region : {value: region, type:"Region"})

--- a/python/parser.js
+++ b/python/parser.js
@@ -20,10 +20,10 @@ function checkSettings(cs) {
     }
     if (cs.floatingRegions) options += floatingRegions(cs.floatingRegions)
     if (cs.accessibilityRegions) options += accessibilityRegions(cs.accessibilityRegions)
-    if (cs.ignoreRegions) options += regions("ignore", cs.ignoreRegions)
+    if (cs.ignoreRegions) {options += regions("ignore", cs.ignoreRegions)}
     if (cs.layoutRegions) options += regions("layout", cs.layoutRegions)
-    if (cs.contentRegions) options += regions("content", cs.contentRegions)
-    if (cs.strictRegions) options += regions("strict", cs.strictRegions)
+    if (cs.contentRegions) {options += regions("content", cs.contentRegions)}
+    if (cs.strictRegions) {options += regions("strict", cs.strictRegions)}
     if (cs.layoutBreakpoints) options += layoutBreakpoints(cs.layoutBreakpoints)
     if (cs.scrollRootElement) options += `.scroll_root_element(${printSelector(cs.scrollRootElement)})`
     if (cs.ignoreDisplacements) options += `.ignore_displacements(${capitalizeFirstLetter(cs.ignoreDisplacements)})`
@@ -96,7 +96,7 @@ function region(region_param, first_call) {
 }
 
 function regions(kind, arr) {
-    return arr.reduce((acc, val) => `${acc}.${kind}(${regionParameter(val)})`, '')
+    return arr.reduce((acc, val) => `${acc}.${kind}(${regionParameter(val)})`, "")
 }
 function layoutBreakpoints(arg){
     if (Array.isArray(arg)) {
@@ -139,7 +139,7 @@ function regionParameter(region) {
                 string = python`${region.region}, padding=${region.padding}`
             } else {
                 string = parseObject(
-                    region.type ? region : (region.shadow ? region : {value: region, type:'Region'})
+                    region.type ? region : (region.shadow ? region : {value: region, type:"Region"})
                 )
             }
             break;

--- a/python/parser.js
+++ b/python/parser.js
@@ -96,7 +96,7 @@ function region(region_param, first_call) {
 }
 
 function regions(kind, arr) {
-    return arr.reduce((acc, val) => `${acc}.${kind}(${regionParameter(val)})`, "")
+    return arr.reduce((acc, val) => `${acc}.${kind}(${regionParameter(val)})`, "");
 }
 function layoutBreakpoints(arg){
     if (Array.isArray(arg)) {
@@ -136,11 +136,11 @@ function regionParameter(region) {
             break;
         case "object":
             if (region.region) {
-                string = python`${region.region}, padding=${region.padding}`
+                string = python`${region.region}, padding=${region.padding}`;
             } else {
                 string = parseObject(
                     region.type ? region : (region.shadow ? region : {value: region, type:"Region"})
-                )
+                );
             }
             break;
         case "undefined":


### PR DESCRIPTION
Transforms template call
```
eyes.check({
      isFully: true,
      ignoreRegions: [{region: '#ignoreRegions', padding: 20}],
      layoutRegions: [{region: '#layoutRegions', padding: {top: 20, right: 20}}],
      contentRegions: [{region: '#contentRegions', padding: {right: 20, left: 20}}],
      strictRegions: [{region: '#strictRegions', padding: {bottom: 20} }]
    })
```
to
```
Target.window().ignore("#ignoreRegions", padding=20).layout("#layoutRegions", padding={"top":20,"right":20}).content("#contentRegions", padding={"right":20,"left":20}).strict("#strictRegions", padding={"bottom":20}).fully(True)
```