### PR TITLE
Add lazy load inside scrollable area

### DIFF
--- a/coverage-tests.js
+++ b/coverage-tests.js
@@ -42,6 +42,7 @@ config({
     AdoptedStyleSheets: 'https://applitools.github.io/demo/TestPages/AdoptedStyleSheets/index.html',
     ShadowDOM: 'https://applitools.github.io/demo/TestPages/ShadowDOM/index.html',
     LazyLoad: 'https://applitools.github.io/demo/TestPages/LazyLoad/',
+    LazyLoadInsideScrollableArea: 'https://applitools.github.io/demo/TestPages/LazyLoad/insideScrollableArea.html',
     CodedRegionPage: 'https://applitools.github.io/demo/TestPages/CodedRegionPage/index.html',
     LongPage: 'https://applitools.github.io/demo/TestPages/LongPage/index.html',
   },
@@ -2339,6 +2340,18 @@ test('lazy load page with one option specified maxAmountToScroll', {
     eyes.check({isFully: true, lazyLoad: {
        maxAmountToScroll: 10000, 
     }})
+    eyes.close()
+  },
+})
+
+test('lazy load inside scrollRootElement', {
+  page: 'LazyLoadInsideScrollableArea',
+  variants: {
+    '': {config: {baselineName: 'LazyLoad'}},
+  },
+  test({eyes, assert, helpers}) {
+    eyes.open({appName: 'Applitools Eyes SDK', viewportSize})
+    eyes.check({scrollRootElement: '#sre', isFully: true, lazyLoad: true})
     eyes.close()
   },
 })


### PR DESCRIPTION
Part of a new feature [lazy load in SRE](https://github.com/applitools/eyes.sdk.javascript1/pull/1195)

Tested on `eyes-webdriverio-5` [test](https://eyes.applitools.com/app/test-results/00000251731268701222/00000251731268701066/steps/1?accountId=UAujt6tHnEKUivQXIz7G6A~~&mode=step-editor)
