### PR TITLE
test: add AdjustDocumentHeight for testing UFG options

### DIFF
--- a/coverage-tests.js
+++ b/coverage-tests.js
@@ -45,6 +45,7 @@ config({
     LazyLoadInsideScrollableArea: 'https://applitools.github.io/demo/TestPages/LazyLoad/insideScrollableArea.html',
     CodedRegionPage: 'https://applitools.github.io/demo/TestPages/CodedRegionPage/index.html',
     LongPage: 'https://applitools.github.io/demo/TestPages/LongPage/index.html',
+    AdjustDocumentHeight: 'http://applitools.github.io/demo/TestPages/ufg-options.html'
   },
 })
 
@@ -2436,6 +2437,22 @@ test('should capture webview when specified in check settings on android', {
     eyes.check({webview: 'WEBVIEW_com.applitools.eyes.android'})
     eyes.close()
   },
+})
+
+test('should send adjustDocumentHeight to ufg', {
+  page: 'AdjustDocumentHeight',
+  vg: true,
+  config: {
+    browsersInfo: [
+      {name: 'chrome', width: 640, height: 480},
+    ],
+  },
+  test({eyes}) {
+    eyes.open({appName: 'Applitools Eyes SDK', viewportSize})
+    eyes.check({isFully: false, visualGridOptions: {'"chrome:adjustDocumentHeight"': false}})
+    eyes.check({isFully: false, visualGridOptions: {'"chrome:adjustDocumentHeight"': true}})
+    eyes.close()
+  }
 })
 
 // #endregion

--- a/coverage-tests.js
+++ b/coverage-tests.js
@@ -2439,7 +2439,7 @@ test('should capture webview when specified in check settings on android', {
   },
 })
 
-test('should send adjustDocumentHeight to ufg', {
+test('should send ufg options', {
   page: 'AdjustDocumentHeight',
   vg: true,
   config: {


### PR DESCRIPTION
Because the support of firefox with [adopted styleSheets](https://developer.mozilla.org/en-US/docs/Web/API/Document/adoptedStyleSheets#browser_compatibility) the testing of the sending [ufgOptions](https://github.com/applitools/eyes.sdk.javascript1/blob/698280821fe0430e81531e684e090d39379d5cdf/js/packages/core/docs/universal.md#L519) isn't testing this flow

In the new test we are testing the request to `chrome:adjustDocumentHeight` which change style
