### PR TITLE
Rename removeDuplicateTestsPerBatch test config option

### DIFF
--- a/coverage-tests.js
+++ b/coverage-tests.js
@@ -2469,7 +2469,7 @@ test('should skip removal of duplicate test results when baseline name used', {
     'with ufg': {vg: true},
   },
   config: {
-    removeDuplicateTestsPerBatch: true,
+    removeDuplicateTests: true,
     baselineEnvName: 'default-page',
   },
   test({eyes, assert}) {


### PR DESCRIPTION
Looks like it was renamed everywhere else and this was fogotten