### PR TITLE
[py] support for `Should return exception in TestResultsSummary` test

### DIFF
--- a/coverage-tests.js
+++ b/coverage-tests.js
@@ -2296,7 +2296,7 @@ test('Should return exception in TestResultsSummary', {
     eyes.check({isFully: false})
     assert.throws(() => void eyes.close())
     const summary = eyes.runner.getAllTestResults(false)
-    assert.contains( summary.getAllResults()[0].getException().message, `This page's DOM has a feature, Adopted Stylesheets`)
+    assert.contains( summary.getAllResults()[0].exception.message, `This page's DOM has a feature, Adopted Stylesheets`)
   }
 })
 

--- a/python/emitter.js
+++ b/python/emitter.js
@@ -366,6 +366,9 @@ def execution_grid():
                         items: {
                             type: 'TestResultContainer',
                             schema: {
+                                exception: {
+                                    type: "Exception",
+                                },
                                 testResults: {
                                     type: "TestResults",
                                     schema: {
@@ -574,6 +577,9 @@ def execution_grid():
     }
 
     const assert = {
+        contains(object, value) {
+            return addCommand(python`assert ${value} in ${object}`)
+        },
         equal(actual, expected, message) {
             if (expected === null) return addCommand(python`assert ${actual} is None`)
             if ((expected && expected.isRef) && (JSON.stringify(expected) === undefined)) return addCommand(python`assert ${actual} == ` + expected.ref())

--- a/python/mapping/types.js
+++ b/python/mapping/types.js
@@ -131,6 +131,9 @@ const types = {
     },
     "ChromeEmulationInfo": {
         get: (target, key) => key === 'deviceName' ? `${target}.device_name.value` : simpleGetter(target, key),
+    },
+    "Exception": {
+        get: (target, key) => key === "message" ? `str(${target})`: simpleGetter(target, key),
     }
 }
 module.exports = types


### PR DESCRIPTION
In order to write emitters for this test, I have to fix the test code itself too.
Currently test code calls `.getException()` on TestResultContainer object which is a kind of syntax I didn't find a way to define in python emitter. So I propose to replace It with overridable syntax, `.exception`.
Js emitter needs to reflect this change. SDKs in other languages doesn't seem to implement it (likely because it's not possible).