### PR TITLE
removed `headless: false` from a test

### DIFF
--- a/coverage-tests.js
+++ b/coverage-tests.js
@@ -1625,7 +1625,7 @@ test('should extract text regions from image', {
 
 test('should return actual viewport size', {
   page: 'Default',
-  env: {browser: 'chrome', headless: false},
+  env: {browser: 'chrome'},
   test({driver, eyes, assert}) {
     eyes.open({
       appName: 'Eyes Selenium SDK - Fluent API',


### PR DESCRIPTION
The test 'should return actual viewport size' was using `headless: false` which doesn't mean anything as it was always running on docker which is headless by default. If you'd try to run this test as-is without docker it'll fail. Removing this feature fixes this issue.